### PR TITLE
Refactor/net http

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,12 +3,21 @@ package main
 import (
 	"log"
 
-	"github.com/kptm-tools/core-service/pkg/http"
+	"github.com/kptm-tools/core-service/pkg/api"
+	"github.com/kptm-tools/core-service/pkg/handlers"
+	"github.com/kptm-tools/core-service/pkg/services"
 )
 
 func main() {
 
-	s := http.NewAPIServer(":8000")
+	// Services
+	targetService := services.NewTargetService()
+
+	// Handlers
+	targetHandlers := handlers.NewTargetHandlers(targetService)
+
+	// Server
+	s := api.NewAPIServer(":8000", targetHandlers)
 
 	err := s.Init()
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,13 +1,17 @@
-package http
+package api
 
 import (
 	"encoding/json"
 	"log"
 	"net/http"
+
+	"github.com/kptm-tools/core-service/pkg/interfaces"
 )
 
 type APIServer struct {
 	listenAddr string
+
+	targetHandler interfaces.ITargetHandlers
 }
 
 type APIError struct {
@@ -16,9 +20,11 @@ type APIError struct {
 
 type APIFunc func(http.ResponseWriter, *http.Request) error
 
-func NewAPIServer(listenAddr string) *APIServer {
+func NewAPIServer(listenAddr string, uHandlers interfaces.ITargetHandlers) *APIServer {
 	return &APIServer{
 		listenAddr: listenAddr,
+
+		targetHandler: uHandlers,
 	}
 }
 
@@ -26,6 +32,8 @@ func (s *APIServer) Init() error {
 	router := http.NewServeMux()
 
 	router.HandleFunc("/healthcheck", makeHTTPHandlerFunc(HandleHealthCheck))
+
+	router.HandleFunc("/targets", makeHTTPHandlerFunc(s.targetHandler.GetAllTargets))
 
 	server := http.Server{
 		Addr: s.listenAddr,

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -1,0 +1,1 @@
+package api

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -1,7 +1,0 @@
-package handlers
-
-import "github.com/gofiber/fiber/v2"
-
-func HandleHealthCheck(c *fiber.Ctx) error {
-	return c.SendString("Healthcheck - OK")
-}

--- a/pkg/handlers/target.go
+++ b/pkg/handlers/target.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/kptm-tools/core-service/pkg/api"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+)
+
+type TargetHandlers struct {
+	targetService interfaces.ITargetService
+}
+
+var _ interfaces.ITargetHandlers = (*TargetHandlers)(nil)
+
+func NewTargetHandlers(targetService interfaces.ITargetService) *TargetHandlers {
+	return &TargetHandlers{
+		targetService: targetService,
+	}
+}
+
+func (h *TargetHandlers) GetAllTargets(w http.ResponseWriter, req *http.Request) error {
+
+	targets, err := h.targetService.GetAllTargets("9ca3bc6c-4b78-472d-9194-62bb75d3e9fa")
+
+	if err != nil {
+		return api.WriteJSON(w, http.StatusInternalServerError, err.Error())
+	}
+
+	return api.WriteJSON(w, http.StatusOK, targets)
+}

--- a/pkg/interfaces/target.go
+++ b/pkg/interfaces/target.go
@@ -1,0 +1,15 @@
+package interfaces
+
+import (
+	"net/http"
+
+	"github.com/kptm-tools/core-service/pkg/domain"
+)
+
+type ITargetService interface {
+	GetAllTargets(tenantID string) (*[]domain.Target, error)
+}
+
+type ITargetHandlers interface {
+	GetAllTargets(w http.ResponseWriter, req *http.Request) error
+}

--- a/pkg/services/target.go
+++ b/pkg/services/target.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"time"
+
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+)
+
+type TargetService struct {
+}
+
+var _ interfaces.ITargetService = (*TargetService)(nil)
+
+func NewTargetService() *TargetService {
+	return &TargetService{}
+}
+
+func (s *TargetService) GetAllTargets(tenantID string) (*[]domain.Target, error) {
+
+	targets := &[]domain.Target{
+
+		{
+			ID:        "1",
+			TenantID:  "fcde6d34-ac73-4f29-8e48-bdc5670e1d69",
+			UserID:    "74eb9201-2926-40bb-9f8c-a3a52b3b5db7",
+			Value:     "www.facebook.com",
+			Type:      domain.TargetType(domain.Domain),
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+		{
+			ID:        "2",
+			TenantID:  "fcde6d34-ac73-4f29-8e48-bdc5670e1d69",
+			UserID:    "74eb9201-2926-40bb-9f8c-a3a52b3b5db7",
+			Value:     "www.google.com",
+			Type:      domain.TargetType(domain.Domain),
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+
+	return targets, nil
+}


### PR DESCRIPTION
- Refactored API to use `net/http` instead of `Fiber`
- Add hexagonal architecture to directory structure