### PR TITLE
Refactor/kt 39 auth quality assurance

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -50,11 +50,11 @@ func (s *APIServer) Init() error {
 	// Auth routes
 	router.HandleFunc("POST /api/login", makeHTTPHandlerFunc(s.authHandlers.Login))
 	router.HandleFunc("POST /api/tenant", makeHTTPHandlerFunc(s.authHandlers.RegisterTenant))
-	router.HandleFunc("GET /api/user/{id}", WithAuth(makeHTTPHandlerFunc(s.authHandlers.GetUser), "getUser"))
+	router.HandleFunc("GET /api/user/{id}", middleware.WithAuth(makeHTTPHandlerFunc(s.authHandlers.GetUser), "getUser"))
 
 	router.HandleFunc("POST /hosts", makeHTTPHandlerFunc(s.hostHandlers.CreateHost))
 	router.HandleFunc("GET /hosts", makeHTTPHandlerFunc(s.hostHandlers.GetHostsByTenantID))
-	router.HandleFunc("GET /tenants", WithAuth(makeHTTPHandlerFunc(s.tenantHandlers.GetTenants), "tenants"))
+	router.HandleFunc("GET /tenants", middleware.WithAuth(makeHTTPHandlerFunc(s.tenantHandlers.GetTenants), "tenants"))
 
 	stack := middleware.CreateStack(
 		middleware.Logging,

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -18,6 +18,42 @@ import (
 	"github.com/kptm-tools/core-service/pkg/storage"
 )
 
+type InvalidTokenError struct {
+	msg string
+}
+
+func (e *InvalidTokenError) Error() string {
+	return e.msg
+}
+
+func NewInvalidTokenError(msg string) error {
+	return &InvalidTokenError{msg}
+}
+
+type NoTokenError struct {
+	msg string
+}
+
+func (e *NoTokenError) Error() string {
+	return e.msg
+}
+
+func NewNoTokenError(msg string) error {
+	return &NoTokenError{msg}
+}
+
+type UserNotFoundError struct {
+	msg string
+}
+
+func (e *UserNotFoundError) Error() string {
+	return e.msg
+}
+
+func NewUserNotFoundError(msg string) error {
+	return &UserNotFoundError{msg}
+}
+
 var verifyKey *rsa.PublicKey
 
 type ContextKey string
@@ -29,121 +65,180 @@ func WriteUnauthorized(w http.ResponseWriter) {
 	w.Write([]byte(http.StatusText(http.StatusUnauthorized)))
 }
 
+func WriteInternalServerError(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
+}
+
 func WithAuth(endpoint http.HandlerFunc, functionName string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqToken := ""
-		tokenCookie, err := r.Cookie("app.at")
-
+		token, err := parseToken(r)
 		if err != nil {
-			if errors.Is(err, http.ErrNoCookie) {
-				reqToken = r.Header.Get("Authorization")
-				splitToken := strings.Split(reqToken, "Bearer ")
-
-				if len(splitToken) > 1 {
-					reqToken = splitToken[1]
-				}
-			} else {
-				log.Printf("Error parsing req token: `%s`", err.Error())
+			var invalidTokenErr *InvalidTokenError
+			if errors.As(err, &invalidTokenErr) {
+				log.Println("Error validating token: ", invalidTokenErr.Error())
 				WriteUnauthorized(w)
 				return
+			} else {
+				// General error
+				log.Println("General error: ", err.Error())
+				WriteInternalServerError(w)
+				return
 			}
-		} else {
-			reqToken = tokenCookie.Value
-
 		}
 
-		if reqToken == "" {
-			log.Printf("No token provided\n")
+		// At this point we have the JWT, so we use /golang-jwt/jwt to validate it
+		// And then check roles
+		if !token.Valid {
+			log.Printf("Error validating token: `Invalid token`\n")
 			WriteUnauthorized(w)
 			return
-		} else {
-			token, err := jwt.Parse(reqToken, func(token *jwt.Token) (interface{}, error) {
-				// 1. Check signing method
-				if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-					return nil, fmt.Errorf("Invalid signing method")
-				}
-
-				// 2. Check aud: make sure the token is intended for this application
-
-				/*aud := config.LoadConfig().ApplicationID
-				checkAudience := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
-
-				if !checkAudience {
-					return nil, fmt.Errorf("Invalid audience")
-				}
-				*/
-
-				// verify iss claim: Make sure the issuer is as expected
-				iss := "https://app.kriptome.com" // TODO: Set this to env var
-				checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
-				if !checkIss {
-					return nil, fmt.Errorf(("invalid iss"))
-				}
-
-				if err := setPublicKey(token.Header["kid"].(string)); err != nil {
-					return nil, fmt.Errorf("Error setting public key")
-				}
-
-				return verifyKey, nil
-			})
-
-			if err != nil {
-				log.Printf("Error parsing request token: `%s`\n", err.Error())
-				WriteUnauthorized(w)
-				return
-			}
-
-			// At this point we have the JWT, so we use /golang-jwt/jwt to validate it
-			// And then check roles
-
-			if !token.Valid {
-				log.Printf("Error validating token: `Invalid token`\n")
-				WriteUnauthorized(w)
-				return
-			}
-			var tenantID = token.Claims.(jwt.MapClaims)["tid"]
-			var userID = token.Claims.(jwt.MapClaims)["sub"]
-
-			// Verify that said user exists
-			exists, err := validateUserWithFusionAuth(userID.(string), tenantID.(string))
-			if !exists {
-				log.Printf("User is not registered\n")
-				WriteUnauthorized(w)
-				return
-			}
-
-			var roles = token.Claims.(jwt.MapClaims)["roles"]
-			parsedRoles, err := domain.GetRolesFromStringSlice([]string{roles.([]interface{})[0].(string)})
-
-			if err != nil {
-				log.Printf("Invalid Role: `%s`", err.Error())
-				WriteUnauthorized(w)
-				return
-			}
-
-			// Check out what page we're calling, so we can check relevant roles
-			validRoles, err := domain.GetValidRoles(functionName)
-			if err != nil {
-				log.Printf("Invalid Role: `%v`, must be one of `%v`\n", parsedRoles, validRoles)
-				WriteUnauthorized(w)
-				return
-			}
-
-			result := domain.ContainsRole(parsedRoles, validRoles)
-
-			// If the length of the intersection is >= 1 , we have the proper role
-			// log.Printf("Intersection result: `%v`\n", result)
-			if len(result) == 0 {
-
-				log.Printf("Roles missing: Have `%v`, want one of `%v`\n", parsedRoles, validRoles)
-				WriteUnauthorized(w)
-				return
-			}
-			ctx := context.WithValue(r.Context(), ContextTenantID, tenantID)
-			endpoint(w, r.WithContext(ctx))
-
 		}
+
+		// Verify that said user exists
+		var tenantID = token.Claims.(jwt.MapClaims)["tid"]
+		var userID = token.Claims.(jwt.MapClaims)["sub"]
+
+		exists, err := validateUserWithFusionAuth(userID.(string), tenantID.(string))
+		if err != nil {
+			var userNotFoundError *UserNotFoundError
+			if errors.As(err, &userNotFoundError) {
+				log.Println("UserNotFoundError: ", userNotFoundError.Error())
+				WriteUnauthorized(w)
+				return
+			} else {
+				log.Println("Error validating user: ", err.Error())
+				WriteInternalServerError(w)
+				return
+			}
+		}
+		if !exists {
+			log.Printf("User is not registered\n")
+			WriteUnauthorized(w)
+			return
+		}
+
+		// Verify user roles
+		if err := checkTokenRoles(token, functionName); err != nil {
+			var invalidTokenErr *InvalidTokenError
+			if errors.As(err, &invalidTokenErr) {
+				log.Printf("Error validating token: `%+v`\n", err)
+				WriteUnauthorized(w)
+				return
+			}
+			log.Println("General error: ", err.Error())
+			WriteInternalServerError(w)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), ContextTenantID, tenantID)
+		endpoint(w, r.WithContext(ctx))
+
 	})
+}
+
+func parseToken(r *http.Request) (*jwt.Token, error) {
+
+	reqToken, err := getRequestToken(r)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := jwt.Parse(reqToken, func(token *jwt.Token) (interface{}, error) {
+		// 1. Check signing method
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			msg := "Invalid signing method"
+			return nil, NewInvalidTokenError(msg)
+		}
+
+		// 2. Check aud: make sure the token is intended for this application
+
+		/*aud := config.LoadConfig().ApplicationID
+		checkAudience := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
+
+		if !checkAudience {
+			return nil, fmt.Errorf("Invalid audience")
+		}
+		*/
+
+		// verify iss claim: Make sure the issuer is as expected
+		iss := "https://app.kriptome.com" // TODO: Set this to env var
+		checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
+		if !checkIss {
+			msg := "Invalid iss"
+			return nil, NewInvalidTokenError(msg)
+		}
+
+		if err := setPublicKey(token.Header["kid"].(string)); err != nil {
+			return nil, fmt.Errorf("Error setting public key")
+		}
+
+		return verifyKey, nil
+	})
+
+	return token, nil
+}
+
+// getRequestToken gets the request's token, from either
+// the cookie or the header. Returns a [NoTokenError] on failure
+func getRequestToken(r *http.Request) (string, error) {
+	reqToken := ""
+	tokenCookie, err := r.Cookie("app.at")
+
+	// If token was not in cookie
+	if err != nil {
+		// If there's no cookie, attempt to extract from header
+		if errors.Is(err, http.ErrNoCookie) {
+			reqToken = r.Header.Get("Authorization")
+			splitToken := strings.Split(reqToken, "Bearer ")
+
+			if len(splitToken) > 1 {
+				reqToken = splitToken[1]
+			}
+
+		} else {
+			// There was a cookie, but there was an error parsing it
+			msg := fmt.Sprintf("Error parsing cookie token: `%s`", err.Error())
+			return "", NewNoTokenError(msg)
+		}
+	} else {
+		reqToken = tokenCookie.Value
+	}
+
+	// If token is empty
+	if reqToken == "" {
+		msg := "No token provided in cookie or header"
+		return "", NewNoTokenError(msg)
+	}
+
+	return reqToken, nil
+}
+
+func checkTokenRoles(token *jwt.Token, functionName string) error {
+	var roles = token.Claims.(jwt.MapClaims)["roles"]
+	parsedRoles, err := domain.GetRolesFromStringSlice([]string{roles.([]interface{})[0].(string)})
+
+	if err != nil {
+		msg := fmt.Sprintf("Invalid Role: `%s`", err.Error())
+		return NewInvalidTokenError(msg)
+	}
+
+	// Check out what page we're calling, so we can check relevant roles
+	validRoles, err := domain.GetValidRoles(functionName)
+	if err != nil {
+		msg := fmt.Sprintf("Invalid Role: `%v`, must be one of `%v`", parsedRoles, validRoles)
+		return NewInvalidTokenError(msg)
+	}
+
+	result := domain.ContainsRole(parsedRoles, validRoles)
+	// If the length of the intersection is >= 1 , we have the proper role
+	// log.Printf("Intersection result: `%v`\n", result)
+	if len(result) == 0 {
+		msg := fmt.Sprintf("Roles missing: Have `%v`, want one of `%v`", parsedRoles, validRoles)
+		return NewInvalidTokenError(msg)
+	}
+
+	return nil
 }
 
 func setPublicKey(kid string) error {
@@ -186,8 +281,16 @@ func validateUserWithFusionAuth(userID, tenantID string) (bool, error) {
 
 	_, err := authService.GetUserByID(userID, &tenantID)
 	if err != nil {
-		log.Printf("Error fetching user: `%s`\n", err.Error())
-		return false, err
+		var faErr *services.FaError
+		if errors.As(err, &faErr) {
+			msg := faErr.Error()
+			log.Printf("FusionAuth error fetching user: `%s`", msg)
+			return false, NewUserNotFoundError(msg)
+
+		} else {
+			log.Printf("Error fetching user: `%s`\n", err.Error())
+			return false, err
+		}
 	}
 
 	return true, nil

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -1,4 +1,4 @@
-package api
+package middleware
 
 import (
 	"context"

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -191,8 +191,13 @@ func getRequestToken(r *http.Request) (string, error) {
 
 func checkTokenRoles(token *jwt.Token, functionName string) error {
 	var roles = token.Claims.(jwt.MapClaims)["roles"]
-	parsedRoles, err := domain.GetRolesFromStringSlice([]string{roles.([]interface{})[0].(string)})
+	// Check if we have any roles in our claims
+	if len(roles.([]interface{})) == 0 {
+		msg := "Token has no roles"
+		return fmt.Errorf("%q: %w", msg, InvalidTokenError)
+	}
 
+	parsedRoles, err := domain.GetRolesFromStringSlice([]string{roles.([]interface{})[0].(string)})
 	if err != nil {
 		msg := fmt.Sprintf("Invalid Role: `%s`", err.Error())
 		return fmt.Errorf("%q: %w", msg, InvalidTokenError)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -158,6 +158,9 @@ func validateClaims(token *jwt.Token) error {
 	if err := validateIssuer(claims, "https://app.kriptome.com"); err != nil {
 		return err
 	}
+	if err := validateUserAndTenant(claims); err != nil {
+		return err
+	}
 	if err := validateKID(token); err != nil {
 		return err
 	}
@@ -166,7 +169,7 @@ func validateClaims(token *jwt.Token) error {
 
 // verify iss claim: Make sure the issuer is as expected
 func validateIssuer(claims jwt.MapClaims, issuer string) error {
-	checkIss := claims.VerifyIssuer(issuer, false)
+	checkIss := claims.VerifyIssuer(issuer, true)
 	if !checkIss {
 		msg := "Invalid iss"
 		return fmt.Errorf("%q: %w", msg, InvalidTokenError)
@@ -179,6 +182,20 @@ func validateKID(token *jwt.Token) error {
 	kid, ok := token.Header["kid"].(string)
 	if !ok || kid == "" {
 		msg := "Missing kid header"
+		return fmt.Errorf("%q: %w", msg, InvalidTokenError)
+	}
+	return nil
+}
+
+func validateUserAndTenant(claims jwt.MapClaims) error {
+	userID, ok := claims["sub"]
+	if !ok || userID == "" {
+		msg := "Missing userID claim"
+		return fmt.Errorf("%q: %w", msg, InvalidTokenError)
+	}
+	tenantID, ok := claims["tid"]
+	if !ok || tenantID == "" {
+		msg := "Missing tenantID claim"
 		return fmt.Errorf("%q: %w", msg, InvalidTokenError)
 	}
 	return nil

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -1,0 +1,151 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type parseTokenTestCase struct {
+	name          string
+	tokenString   string
+	setupRequest  func(req *http.Request)
+	expectedError error
+	expectedValid bool
+}
+
+func createPrivateTestKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 2048)
+}
+
+func createValidTestTokenString() string {
+	testPrivateKey, err := createPrivateTestKey()
+	if err != nil {
+		panic(err)
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": "https://app.kriptome.com",
+		"tid": "test-tenant-id",
+		"sub": "test-user-id",
+	})
+	tokenString, err := token.SignedString(testPrivateKey)
+	if err != nil {
+		panic(err)
+	}
+
+	return tokenString
+}
+
+func Test_getRequestToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   func() *http.Request
+		wantToken string
+		wantErr   error
+	}{
+		{
+			name: "Token in header",
+			request: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Authorization", "Bearer test-token")
+				return r
+			},
+			wantToken: "test-token",
+			wantErr:   nil,
+		},
+		{
+			name: "Token in cookie",
+			request: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.AddCookie(&http.Cookie{Name: "app.at", Value: "test-token"})
+				return r
+			},
+			wantToken: "test-token",
+			wantErr:   nil,
+		},
+		{
+			name: "No token provided",
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/", nil)
+			},
+			wantToken: "",
+			wantErr:   NoTokenError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.request()
+			token, err := getRequestToken(req)
+
+			if token != tt.wantToken {
+				t.Errorf("Expected token `%v`, got `%v`", tt.wantToken, token)
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Expected error `%v`, got `%v`", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// func Test_parseToken(t *testing.T) {
+//
+// 	validTokenString := createValidTestTokenString()
+// 	// invalidTokenString := createInvalidTokenString()
+// 	// invalidSigningMethodTokenString := createInvalidSigningMethodTokenString()
+//
+// 	// Arrange
+// 	testCases := []parseTokenTestCase{
+// 		{
+// 			name:        "Valid token in Authorization Header",
+// 			tokenString: validTokenString,
+// 			setupRequest: func(req *http.Request) {
+// 				req.Header.Set("Authorization", "Bearer "+validTokenString)
+// 			},
+// 			expectedError: nil,
+// 			expectedValid: true,
+// 		},
+// 		{
+// 			name:        "Token with invalid issuer in Authorization Header",
+// 			tokenString: validTokenString,
+// 			setupRequest: func(req *http.Request) {
+// 				req.Header.Set("Authorization", "Bearer "+validTokenString)
+// 			},
+// 			expectedError: nil,
+// 			expectedValid: false,
+// 		},
+// 	}
+//
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			req := httptest.NewRequest(http.MethodGet, "/", nil)
+// 			if tt.setupRequest != nil {
+// 				tt.setupRequest(req)
+// 			}
+//
+// 			token, err := parseToken(req)
+// 			if err != nil && tt.expectedError != nil {
+// 				if err.Error() != tt.expectedError.Error() {
+// 					t.Errorf("Expected error: `%v`, got: `%v`", tt.expectedError, err)
+// 				}
+// 			} else if err == nil && tt.expectedError != nil {
+// 				t.Errorf("Expected error: `%v`, got nil", tt.expectedError)
+// 			} else if err != nil && tt.expectedError == nil {
+// 				t.Errorf("Expected no error, got: `%v`", err)
+// 			}
+//
+// 			if token != nil && !tt.expectedValid {
+// 				t.Errorf("Expected token to be invalid, but it was valid")
+// 			} else if token == nil && tt.expectedValid {
+// 				t.Errorf("Expected token to be valid, but it was nil")
+// 			}
+// 		})
+// 	}
+//
+// }

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -160,6 +160,8 @@ func Test_validateClaims(t *testing.T) {
 			name: "Token with valid claims",
 			tokenClaims: jwt.MapClaims{
 				"iss": "https://app.kriptome.com",
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
 			},
 			tokenHeaders: map[string]interface{}{
 				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
@@ -170,6 +172,8 @@ func Test_validateClaims(t *testing.T) {
 			name: "Token with invalid issuer",
 			tokenClaims: jwt.MapClaims{
 				"iss": "https://invalid.issuer.com",
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
 			},
 			tokenHeaders: map[string]interface{}{
 				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
@@ -180,6 +184,8 @@ func Test_validateClaims(t *testing.T) {
 			name: "Token with no token headers",
 			tokenClaims: jwt.MapClaims{
 				"iss": "https://invalid.issuer.com",
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
 			},
 			tokenHeaders: map[string]interface{}{},
 			wantErr:      InvalidTokenError,
@@ -188,6 +194,8 @@ func Test_validateClaims(t *testing.T) {
 			name: "Token with empty kid header",
 			tokenClaims: jwt.MapClaims{
 				"iss": "https://invalid.issuer.com",
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
 			},
 			tokenHeaders: map[string]interface{}{
 				"kid": "",
@@ -205,6 +213,39 @@ func Test_validateClaims(t *testing.T) {
 		{
 			name:        "Token with no claims",
 			tokenClaims: nil,
+			tokenHeaders: map[string]interface{}{
+				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
+			},
+			wantErr: InvalidTokenError,
+		},
+		{
+			name: "Token with no iss claim",
+			tokenClaims: jwt.MapClaims{
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+			},
+			tokenHeaders: map[string]interface{}{
+				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
+			},
+			wantErr: InvalidTokenError,
+		},
+		{
+			name: "Token with no userID claim",
+			tokenClaims: jwt.MapClaims{
+				"iss": "https://invalid.issuer.com",
+				"tid": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+			},
+			tokenHeaders: map[string]interface{}{
+				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
+			},
+			wantErr: InvalidTokenError,
+		},
+		{
+			name: "Token with no tenantID claim",
+			tokenClaims: jwt.MapClaims{
+				"iss": "https://invalid.issuer.com",
+				"sub": "b2131c96-bc4d-4dab-86c8-e5ff3e70b3f9",
+			},
 			tokenHeaders: map[string]interface{}{
 				"kid": "b0ffa9ed-7a9f-4d1f-a09d-a81b2a8fb41b",
 			},


### PR DESCRIPTION
Refactored `middleware/auth` to follow cleaner coding practices, and incorporated unit tests into our application specific logic. 

- The HUGE `withAuth` method was broken down into smaller, more granular components which are easier to test and debug. 
- Specific error handling was incorporated as well, following the [Sentinel error pattern](https://bitfieldconsulting.com/posts/wrapping-errors).
     - This error handling pattern is slightly different than what is currently incorporated in `services/auth`. It provides a cleaner way of testing, wrapping and checking for custom error types (using `errors.Is()` instead of `errors.As()`, which is why `services/auth` and `handlers/auth` should be refactored as well in the future to follow this pattern.

- Now `withAuth` doesn't write a JSON response with the specific error, this logging is left to the `core-service`. It is a good idea to keep Unauthorized responses as ambiguous as possible, to prevent unauthorized individuals from knowing why the system is failing to authorize them ;)