### PR TITLE
fix(scan) Fix scan service bug, remove unnecessary concurrency

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,6 @@ github.com/jpillora/go-tld v1.2.1 h1:kDKOkmXLlskqjcvNs7w5XHLep7c8WM7Xd4HQjxllVMk
 github.com/jpillora/go-tld v1.2.1/go.mod h1:plzIl7xr5UWKGy7R+giuv+L/nOjrPjsoWxy/ST9OBUk=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kptm-tools/common v1.2.2 h1:keRdqOY4Tu2j6VER+XT1MVzzSFJwPwKKahyTxVQzNmw=
-github.com/kptm-tools/common v1.2.2/go.mod h1:/xGzfkx6dmO1JDxqNU0OGumqlJq/U4j5XmMG85W3P4s=
-github.com/kptm-tools/common v1.2.3 h1:xQGZdwyx2XgRmvRMDmv2jB3vvCReu5ZhR0qhq+zDmeI=
-github.com/kptm-tools/common v1.2.3/go.mod h1:/xGzfkx6dmO1JDxqNU0OGumqlJq/U4j5XmMG85W3P4s=
-github.com/kptm-tools/common v1.2.4 h1:xFrh6JvloNqVfq5RS0/M9+ZASHQ4FPH2hrLQbcDs7Tw=
-github.com/kptm-tools/common v1.2.4/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
 github.com/kptm-tools/common v1.2.5 h1:+V8b9IyxGqFzXokH707P4MjOGt64r10Od3uoovwRT0A=
 github.com/kptm-tools/common v1.2.5/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/pkg/domain/scan.go
+++ b/pkg/domain/scan.go
@@ -13,8 +13,8 @@ type Metadata struct {
 }
 
 type StatusHost struct {
-	Host     string      `json:"id,omitempty"`
-	Metadata []*Metadata `json:"metadata,omitempty"`
+	Host     string     `json:"id,omitempty"`
+	Metadata []Metadata `json:"metadata,omitempty"`
 }
 
 type ResultHost struct {

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -2,11 +2,11 @@ package services
 
 import (
 	"fmt"
+
 	"github.com/kptm-tools/common/common/events"
 	"github.com/kptm-tools/common/common/results"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
-	"sync"
 )
 
 type ScanService struct {
@@ -28,72 +28,66 @@ type resultChannel struct {
 
 func (s ScanService) CreateScans(hostIDs []string) (*domain.Scan, error) {
 	scanDB := domain.NewScan()
-	dataResults, err := launchScanEvents(s.storage, hostIDs)
-	if err != nil {
-		return nil, err
-	}
 	metadataDefault := createMetadata()
-	for _, result := range dataResults {
-		if result.err != nil {
-			return nil, result.err
+
+	for _, hostID := range hostIDs {
+		// Validate and retrieve host data
+		if hostID == "" {
+			return nil, fmt.Errorf("hostID is empty")
 		}
-		scanDB.HostsStatus = append(scanDB.HostsStatus, *createHostStatus(result.data, metadataDefault))
-		scanDB.Targets = append(scanDB.Targets, *createTarget(result.data))
+
+		host, err := s.storage.GetHostByID(hostID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host: %w", err)
+		}
+
+		// Process the host data into the scan
+		scanDB.HostsStatus = append(scanDB.HostsStatus, createHostStatus(*host, metadataDefault))
+		scanDB.Targets = append(scanDB.Targets, createTarget(*host))
 	}
+
 	dataScan, err := s.storage.CreateScan(scanDB)
-	dataScan.Targets = scanDB.Targets
 	if err != nil {
 		return nil, err
 	}
+
+	dataScan.Targets = scanDB.Targets
 	return dataScan, nil
 }
 
-func launchEvent(s interfaces.IStorage, ch chan resultChannel, wg *sync.WaitGroup, hostID string) {
-	defer wg.Done()
-
-	if hostID == "" {
-		ch <- resultChannel{err: fmt.Errorf("hostID is empty")}
-		return
-	}
-	host, err := s.GetHostByID(hostID)
-	if err != nil {
-		ch <- resultChannel{err: fmt.Errorf("failed to get host: %w", err)}
-		return
-	}
-	ch <- resultChannel{data: *host}
-}
-func createMetadata() []*domain.Metadata {
+func createMetadata() []domain.Metadata {
 	// set dataResults of host in status scan
-	metadataWhois := &domain.Metadata{
+	metadataWhois := domain.Metadata{
 		Progress: "0%",
 		Service:  results.ServiceWhoIs,
 	}
-	metadataHarvester := &domain.Metadata{
+	metadataHarvester := domain.Metadata{
 		Progress: "0%",
 		Service:  results.ServiceHarvester,
 	}
-	metadataDNSLookup := &domain.Metadata{
+	metadataDNSLookup := domain.Metadata{
 		Progress: "0%",
 		Service:  results.ServiceDNSLookup,
 	}
-	metadataNmap := &domain.Metadata{
+	metadataNmap := domain.Metadata{
 		Progress: "0%",
 		Service:  results.ServiceNmap,
 	}
-	return []*domain.Metadata{metadataHarvester, metadataWhois, metadataDNSLookup, metadataNmap}
+	return []domain.Metadata{metadataHarvester, metadataWhois, metadataDNSLookup, metadataNmap}
 }
 
-func createTarget(host domain.Host) *events.Target {
-	hostValue := ""
-	hostType := *new(events.TargetType)
-	if host.IP == "" {
-		hostType = events.Domain
-		hostValue = host.Domain
-	} else {
+func createTarget(host domain.Host) events.Target {
+	var hostValue string
+	var hostType events.TargetType
+	if host.Domain == "" {
 		hostType = events.IP
 		hostValue = host.IP
+	} else {
+		hostType = events.Domain
+		hostValue = host.Domain
 	}
-	target := &events.Target{
+
+	target := events.Target{
 		Alias: host.Name,
 		Value: hostValue,
 		Type:  hostType,
@@ -101,29 +95,10 @@ func createTarget(host domain.Host) *events.Target {
 	return target
 }
 
-func createHostStatus(host domain.Host, metadata []*domain.Metadata) *domain.StatusHost {
-	hostStatus := &domain.StatusHost{
+func createHostStatus(host domain.Host, metadata []domain.Metadata) domain.StatusHost {
+	hostStatus := domain.StatusHost{
 		Host:     host.Name,
 		Metadata: metadata,
 	}
 	return hostStatus
-}
-
-func launchScanEvents(storage interfaces.IStorage, hostIDs []string) ([]resultChannel, error) {
-	var wg sync.WaitGroup
-	var dataResults []resultChannel
-	ch := make(chan resultChannel, len(hostIDs))
-
-	for _, hostID := range hostIDs {
-		wg.Add(1)
-		go launchEvent(storage, ch, &wg, hostID)
-	}
-	go func() {
-		for v := range ch {
-			dataResults = append(dataResults, v)
-		}
-	}()
-	wg.Wait()
-	close(ch)
-	return dataResults, nil
 }


### PR DESCRIPTION
* Fixed an error where `domain.Scan` struct had unintended null values on `Targets` when creating a scan, which led to a ScanStartedEvent failing
* Cleaned up concurrency   

Concurrency is often unnecessary when interacting with a database. Concurrency can add complexity without meaningful performance gains, which was the case here, since it was leading to unintended errors. It's best to leave concurrency for when we discover bottlenecks in our system.