### PR TITLE
fix(auth-middleware) Update auth-middleware error handling

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -48,17 +48,18 @@ func WithAuth(endpoint http.HandlerFunc, functionName string) http.HandlerFunc {
 			if errors.Is(err, ErrInvalidToken) {
 				log.Println(err.Error())
 				WriteUnauthorized(w)
-				return
 			} else if errors.Is(err, ErrNoToken) {
 				log.Println(err.Error())
 				WriteUnauthorized(w)
-				return
+			} else if errors.Is(err, jwt.ErrTokenExpired) {
+				log.Println(err.Error())
+				WriteUnauthorized(w)
 			} else {
 				// General error
 				log.Println("General error: ", err.Error())
 				WriteInternalServerError(w)
-				return
 			}
+			return
 		}
 
 		// At this point we have the JWT, so we use /golang-jwt/jwt to validate it


### PR DESCRIPTION
A check is done for jwt.ErrTokenExpired to see if we should return a 500 or a 401 Unauthorized