### PR TITLE
fix(validate-host) Update validate-host and register-host validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require github.com/FusionAuth/go-client v0.0.0-20241126020005-1254a936741f
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/go-tld v1.2.1
-	github.com/kptm-tools/common v1.2.9
+	github.com/kptm-tools/common v1.2.10
 	github.com/prometheus-community/pro-bing v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,8 @@ github.com/jpillora/go-tld v1.2.1 h1:kDKOkmXLlskqjcvNs7w5XHLep7c8WM7Xd4HQjxllVMk
 github.com/jpillora/go-tld v1.2.1/go.mod h1:plzIl7xr5UWKGy7R+giuv+L/nOjrPjsoWxy/ST9OBUk=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kptm-tools/common v1.2.5 h1:+V8b9IyxGqFzXokH707P4MjOGt64r10Od3uoovwRT0A=
-github.com/kptm-tools/common v1.2.5/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
-github.com/kptm-tools/common v1.2.9 h1:Od300Roo+Q2MKxbnJRGjQs4g8nw2t0p435HAM1s7VIA=
-github.com/kptm-tools/common v1.2.9/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
+github.com/kptm-tools/common v1.2.10 h1:6+zjtuY2xfDy4cTolt3vYwWgzLq9Ku1xkgvhC/4jL6I=
+github.com/kptm-tools/common v1.2.10/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/likexian/gokit v0.25.15 h1:QjospM1eXhdMMHwZRpMKKAHY/Wig9wgcREmLtf9NslY=


### PR DESCRIPTION
Normalized logic (cmmn package) for host value validation to avoid errors.

Both the POST `api/hosts` and POST `api/hosts/validate` should now parse these kinds of values:

- PROTOCOL + DOMAIN
- PROTOCOL + IP
- IP
- DOMAIN