### PR TITLE
fix(host-service) Update CreateHost to retrieve credentials

### DIFF
--- a/pkg/storage/host.go
+++ b/pkg/storage/host.go
@@ -102,7 +102,10 @@ func (s *PostgreSQLStore) CreateHost(t *domain.Host) (*domain.Host, error) {
 	}
 
 	// Retreive and assign credentials
-	newHost.Credentials = t.Credentials
+	newHost.Credentials, err = s.GetCredentials(newHost.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch credentials: %w", err)
+	}
 	return newHost, nil
 }
 


### PR DESCRIPTION
Fixed a bug where POST `api/hosts` returned no `host_id` or `id` attributes for response credentials