### PR TITLE
refactor(cmmn) Update core-service to use new EventSubject consts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require github.com/FusionAuth/go-client v0.0.0-20241126020005-1254a936741f
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/go-tld v1.2.1
-	github.com/kptm-tools/common v1.2.10
+	github.com/kptm-tools/common v1.2.14
 	github.com/prometheus-community/pro-bing v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/jpillora/go-tld v1.2.1 h1:kDKOkmXLlskqjcvNs7w5XHLep7c8WM7Xd4HQjxllVMk
 github.com/jpillora/go-tld v1.2.1/go.mod h1:plzIl7xr5UWKGy7R+giuv+L/nOjrPjsoWxy/ST9OBUk=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/kptm-tools/common v1.2.10 h1:6+zjtuY2xfDy4cTolt3vYwWgzLq9Ku1xkgvhC/4jL6I=
-github.com/kptm-tools/common v1.2.10/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
+github.com/kptm-tools/common v1.2.14 h1:/Ht0gLH/2XGRIHMt4o6BB8jY6XgX9jtyyA1S85iMfPQ=
+github.com/kptm-tools/common v1.2.14/go.mod h1:rbiN3iX3544CBJ4N1As02OH7lkdO1LRBsUuA8+JGKXY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/likexian/gokit v0.25.15 h1:QjospM1eXhdMMHwZRpMKKAHY/Wig9wgcREmLtf9NslY=

--- a/pkg/domain/scan.go
+++ b/pkg/domain/scan.go
@@ -1,15 +1,16 @@
 package domain
 
 import (
-	"github.com/google/uuid"
-	events "github.com/kptm-tools/common/common/events"
-	results "github.com/kptm-tools/common/common/results"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/enums"
+	events "github.com/kptm-tools/common/common/events"
 )
 
 type Metadata struct {
-	Progress string              `json:"progress"`
-	Service  results.ServiceName `json:"service"`
+	Progress string            `json:"progress"`
+	Service  enums.ServiceName `json:"service"`
 }
 
 type StatusHost struct {

--- a/pkg/handlers/host.go
+++ b/pkg/handlers/host.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kptm-tools/common/common/enums"
 	cmmn "github.com/kptm-tools/common/common/events"
 	"github.com/kptm-tools/core-service/pkg/middleware"
 	"github.com/kptm-tools/core-service/pkg/services"
@@ -209,7 +210,7 @@ func constructResponse(host *domain.Host) *domain.HostResponse {
 func getDomainIPValues(createHostRequest *CreateHostRequest, h *HostHandlers) (string, string, error) {
 	domainValue := ""
 	ipValue := ""
-	if createHostRequest.ValueType == string(cmmn.Domain) {
+	if createHostRequest.ValueType == string(enums.Domain) {
 		url := createHostRequest.Value
 		if !cmmn.IsURL(url) {
 			return "", "", fmt.Errorf("invalid url: %s", url)
@@ -232,7 +233,7 @@ func getDomainIPValues(createHostRequest *CreateHostRequest, h *HostHandlers) (s
 		return domain, ipValue, nil
 	}
 
-	if createHostRequest.ValueType == string(cmmn.IP) {
+	if createHostRequest.ValueType == string(enums.IP) {
 		normalizedURL := cmmn.NormalizeURL(createHostRequest.Value)
 
 		ipValue = strings.Split(normalizedURL, "//")[1]
@@ -240,6 +241,6 @@ func getDomainIPValues(createHostRequest *CreateHostRequest, h *HostHandlers) (s
 		return domainValue, ipValue, nil
 	}
 
-	return "", "", fmt.Errorf("invalid host type: must be one of `%s` or `%s`", string(cmmn.Domain), string(cmmn.IP))
+	return "", "", fmt.Errorf("invalid host type: must be one of `%s` or `%s`", string(enums.Domain), string(enums.IP))
 
 }

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/kptm-tools/common/common/enums"
 	cmmn "github.com/kptm-tools/common/common/events"
 	"github.com/kptm-tools/core-service/pkg/api"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
@@ -67,7 +68,7 @@ func (s ScanHandlers) CreateScans(w http.ResponseWriter, req *http.Request) erro
 		Timestamp: scan.CreatedAt.Unix(),
 	}
 	scanStartedBytes, err := json.Marshal(scanStartedPayload)
-	s.eventBus.Publish("ScanStarted", scanStartedBytes)
+	s.eventBus.Publish(string(enums.ScanStartedEventSubject), scanStartedBytes)
 
 	if err != nil {
 

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -3,8 +3,8 @@ package services
 import (
 	"fmt"
 
+	"github.com/kptm-tools/common/common/enums"
 	"github.com/kptm-tools/common/common/events"
-	"github.com/kptm-tools/common/common/results"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 )
@@ -49,31 +49,31 @@ func createMetadata() []domain.Metadata {
 	// set dataResults of host in status scan
 	metadataWhois := domain.Metadata{
 		Progress: "0%",
-		Service:  results.ServiceWhoIs,
+		Service:  enums.ServiceWhoIs,
 	}
 	metadataHarvester := domain.Metadata{
 		Progress: "0%",
-		Service:  results.ServiceHarvester,
+		Service:  enums.ServiceHarvester,
 	}
 	metadataDNSLookup := domain.Metadata{
 		Progress: "0%",
-		Service:  results.ServiceDNSLookup,
+		Service:  enums.ServiceDNSLookup,
 	}
 	metadataNmap := domain.Metadata{
 		Progress: "0%",
-		Service:  results.ServiceNmap,
+		Service:  enums.ServiceNmap,
 	}
 	return []domain.Metadata{metadataHarvester, metadataWhois, metadataDNSLookup, metadataNmap}
 }
 
 func createTarget(host domain.Host) events.Target {
 	var hostValue string
-	var hostType events.TargetType
+	var hostType enums.TargetType
 	if host.Domain == "" {
-		hostType = events.IP
+		hostType = enums.IP
 		hostValue = host.IP
 	} else {
-		hostType = events.Domain
+		hostType = enums.Domain
 		hostValue = host.Domain
 	}
 


### PR DESCRIPTION
These new constants and enumerations from the [latest common package tag](https://github.com/kptm-tools/common) allow us to avoid using magic strings for:

- **EventSubjects**
- **ServiceStatus** (for database scan statuses)
- **TargetTypes**
- **ServiceNames** (e.g: nmap, harvester, whois, etc.)