### PR TITLE
Feature/kt 321 implement vulnerability summary endpoint

### DIFF
--- a/cmd/migrations/000012_add_severity_column_to_scan_vulnerabilities.down.sql
+++ b/cmd/migrations/000012_add_severity_column_to_scan_vulnerabilities.down.sql
@@ -1,0 +1,5 @@
+-- Migration: 000012_add_severity_column_to_scan_vulnerabilities.down.sql
+
+DROP INDEX IF EXISTS idx_scan_vulnerabilities_severity;
+
+ALTER TABLE scan_vulnerabilities DROP COLUMN severity;

--- a/cmd/migrations/000012_add_severity_column_to_scan_vulnerabilities.up.sql
+++ b/cmd/migrations/000012_add_severity_column_to_scan_vulnerabilities.up.sql
@@ -1,0 +1,18 @@
+-- Migration: 000012_add_severity_column_to_scan_vulnerabilities.up.sql
+
+ALTER TABLE scan_vulnerabilities ADD COLUMN severity VARCHAR(20);
+
+UPDATE scan_vulnerabilities
+SET severity =
+  CASE
+    WHEN cvss IS NULL THEN 'None'
+    WHEN cvss < 4.0 THEN 'Low'
+    WHEN cvss >= 4.0 AND cvss < 7.0 THEN 'Medium'
+    WHEN cvss >= 7.0 AND cvss < 9.0 THEN 'High'
+    WHEN cvss >= 9.0  THEN 'Critical'
+    ELSE 'Unknown'
+  END;
+
+ALTER TABLE scan_vulnerabilities ALTER COLUMN severity SET NOT NULL;
+
+CREATE INDEX idx_scan_vulnerabilities_severity ON scan_vulnerabilities(severity);

--- a/cmd/migrations/000013_add_scan_vulnerabilities_severity_trigger.down.sql
+++ b/cmd/migrations/000013_add_scan_vulnerabilities_severity_trigger.down.sql
@@ -1,0 +1,3 @@
+-- Migration: 000013_add_scan_vulnerabilities_severity_trigger.down.sql
+DROP TRIGGER IF EXISTS scan_vulnerabilities_severity_trigger ON scan_vulnerabilities;
+DROP FUNCTION IF EXISTS calculate_scan_vulnerability_severity();

--- a/cmd/migrations/000013_add_scan_vulnerabilities_severity_trigger.up.sql
+++ b/cmd/migrations/000013_add_scan_vulnerabilities_severity_trigger.up.sql
@@ -1,0 +1,21 @@
+-- Migration: 000013_add_scan_vulnerabilities_severity_trigger.up.sql
+CREATE OR REPLACE FUNCTION calculate_scan_vulnerability_severity()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.severity := CASE
+    WHEN NEW.cvss IS NULL THEN 'None'
+    WHEN NEW.cvss < 4.0 THEN 'Low'
+    WHEN NEW.cvss >= 4.0 AND NEW.cvss < 7.0 THEN 'Medium'
+    WHEN NEW.cvss >= 7.0 AND NEW.cvss < 9.0 THEN 'High'
+    WHEN NEW.cvss >= 9.0 THEN 'Critical'
+    ELSE 'Unknown'
+  END;
+  RETURN NEW;
+END;
+$$ LANGUAGE PLPGSQL;
+
+-- Trigger to execute the function on INSERT or UPDATE
+CREATE TRIGGER add_scan_vulnerabilities_severity_trigger
+BEFORE INSERT OR UPDATE ON scan_vulnerabilities
+FOR EACH ROW
+EXECUTE FUNCTION calculate_scan_vulnerability_severity();

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -76,6 +76,7 @@ func (s *APIServer) Init() error {
 	router.HandleFunc("GET /api/scans", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScans), "getScans"))
 	router.HandleFunc("POST /api/scans/{id}/cancel", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.CancelScanByID), "cancelScanByID"))
 	router.HandleFunc("GET /api/scans/{id}/insights", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScanInsightsByID), "getScanInsightsByID"))
+	router.HandleFunc("GET /api/scans/{id}/vulnerabilities/summary", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScanVulnerabilitySummaryByID), "getScanVulnerabilitySummaryByID"))
 
 	stack := middleware.CreateStack(
 		middleware.Logging,
@@ -91,18 +92,15 @@ func (s *APIServer) Init() error {
 	log.Println("Server listening on port: ", s.listenAddr)
 
 	return server.ListenAndServe()
-
 }
 
 // This function wraps our APIFunc struct so we can handle errors gracefully
 func makeHTTPHandlerFunc(f APIFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := f(w, r)
-
 		if err != nil {
 			WriteJSON(w, http.StatusInternalServerError, APIError{Error: err.Error()})
 		}
-
 	}
 }
 

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -15,7 +15,7 @@ func (r Role) String() string {
 }
 
 func ParseRole(s string) (Role, error) {
-	var stringToRole = map[string]Role{
+	stringToRole := map[string]Role{
 		"operator": RoleOperator,
 		"analyst":  RoleAnalyst,
 		"admin":    RoleAdmin,
@@ -34,7 +34,6 @@ func GetRolesFromStringSlice(strSlice []string) ([]Role, error) {
 	var res []Role
 	for _, s := range strSlice {
 		v, err := ParseRole(s)
-
 		if err != nil {
 			return nil, err
 		}
@@ -46,23 +45,23 @@ func GetRolesFromStringSlice(strSlice []string) ([]Role, error) {
 }
 
 func GetValidRoles(funcName string) ([]Role, error) {
-
 	funcRoles := map[string][]Role{
-		"handleHealthcheck-fm":    {RoleAdmin},
-		"targets":                 {RoleAdmin, RoleOperator, RoleAnalyst},
-		"tenants":                 {RoleAdmin, RoleAnalyst},
-		"getUser":                 {RoleAdmin, RoleOperator, RoleAnalyst},
-		"newHost":                 {RoleOperator, RoleAnalyst},
-		"getHostsByTenantAndUser": {RoleAdmin, RoleOperator, RoleAnalyst},
-		"getHostByID":             {RoleAdmin, RoleOperator, RoleAnalyst},
-		"deleteHostByID":          {RoleAdmin, RoleOperator},
-		"patchHostByID":           {RoleAdmin, RoleOperator},
-		"validateHost":            {RoleOperator, RoleAnalyst},
-		"validateAlias":           {RoleOperator, RoleAnalyst},
-		"createScans":             {RoleOperator},
-		"getScans":                {RoleOperator, RoleAnalyst},
-		"cancelScanByID":          {RoleOperator},
-		"getScanInsightsByID":     {RoleOperator, RoleAnalyst},
+		"handleHealthcheck-fm":            {RoleAdmin},
+		"targets":                         {RoleAdmin, RoleOperator, RoleAnalyst},
+		"tenants":                         {RoleAdmin, RoleAnalyst},
+		"getUser":                         {RoleAdmin, RoleOperator, RoleAnalyst},
+		"newHost":                         {RoleOperator, RoleAnalyst},
+		"getHostsByTenantAndUser":         {RoleAdmin, RoleOperator, RoleAnalyst},
+		"getHostByID":                     {RoleAdmin, RoleOperator, RoleAnalyst},
+		"deleteHostByID":                  {RoleAdmin, RoleOperator},
+		"patchHostByID":                   {RoleAdmin, RoleOperator},
+		"validateHost":                    {RoleOperator, RoleAnalyst},
+		"validateAlias":                   {RoleOperator, RoleAnalyst},
+		"createScans":                     {RoleOperator},
+		"getScans":                        {RoleOperator, RoleAnalyst},
+		"cancelScanByID":                  {RoleOperator},
+		"getScanInsightsByID":             {RoleOperator, RoleAnalyst},
+		"getScanVulnerabilitySummaryByID": {RoleOperator, RoleAnalyst},
 	}
 
 	v, ok := funcRoles[funcName]
@@ -72,7 +71,6 @@ func GetValidRoles(funcName string) ([]Role, error) {
 	}
 
 	return v, nil
-
 }
 
 // ContainsRole finds the intersection of two arrays
@@ -89,7 +87,6 @@ func ContainsRole(roles []Role, rolesToCheck []Role) []Role {
 
 	// Check elements in the second array against the set
 	for _, role := range rolesToCheck {
-
 		if set[role] {
 			intersection = append(intersection, role)
 		}

--- a/pkg/domain/scan.go
+++ b/pkg/domain/scan.go
@@ -79,6 +79,32 @@ type ScanInsightsMetadata struct {
 	ScanDate  time.Time `json:"scan_date"`
 }
 
+// ScanVulnerabilitySummaryData represents the vulnerability summary data
+// as returned by the service layer. This is distinct from the API response DTO.
+type ScanVulnerabilitySummaryData struct {
+	ScanID               uuid.UUID
+	Domain               string
+	TotalVulnerabilities int
+	SeverityCounts       tools.SeverityCounts
+	CategoryData         []ServiceCategoryData
+	VulnerabilityTrends  ServiceVulnerabilityTrends
+}
+
+type ServiceCategoryData struct {
+	Category string
+	Count    int
+}
+
+type ServiceVulnerabilityTrends struct {
+	TimePeriods               []ServiceTimePeriod
+	AverageVulnerabilityCount float64
+}
+
+type ServiceTimePeriod struct {
+	TimePeriod         string
+	VulnerabilityCount int
+}
+
 func NewScan() *Scan {
 	return &Scan{
 		ID:        uuid.New(),

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
 )
@@ -12,9 +11,9 @@ type RegisterTenantResponse struct {
 }
 
 type ScanVulnerabilitySummaryResponse struct {
-	ScanID         uuid.UUID                   `json:"scan_id"`
+	ScanID         string                      `json:"scan_id"`
 	Domain         string                      `json:"domain"`
-	GenearlSummary VulnerabilityGeneralSummary `json:"general_summary"`
+	GeneralSummary VulnerabilityGeneralSummary `json:"general_summary"`
 }
 
 type VulnerabilityGeneralSummary struct {
@@ -41,4 +40,26 @@ type VulnerabilityTrends struct {
 type TimePeriod struct {
 	TimePeriod         string `json:"time_period"`
 	VulnerabilityCount int    `json:"vulnerability_count"`
+}
+
+func adaptCategoryData(serviceCategoryData []domain.ServiceCategoryData) []CategoryData {
+	adaptedData := make([]CategoryData, len(serviceCategoryData))
+	for i, svcData := range serviceCategoryData {
+		adaptedData[i] = CategoryData{
+			Category: svcData.Category,
+			Count:    svcData.Count,
+		}
+	}
+	return adaptedData
+}
+
+func adaptTimePeriods(serviceTimePeriodData []domain.ServiceTimePeriod) []TimePeriod {
+	adaptedData := make([]TimePeriod, len(serviceTimePeriodData))
+	for i, svcData := range serviceTimePeriodData {
+		adaptedData[i] = TimePeriod{
+			TimePeriod:         svcData.TimePeriod,
+			VulnerabilityCount: svcData.VulnerabilityCount,
+		}
+	}
+	return adaptedData
 }

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -1,10 +1,44 @@
 package handlers
 
 import (
+	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
 )
 
 type RegisterTenantResponse struct {
 	ApplicationID string      `json:"application_id"`
 	User          domain.User `json:"user"`
+}
+
+type ScanVulnerabilitySummaryResponse struct {
+	ScanID         uuid.UUID                   `json:"scan_id"`
+	Domain         string                      `json:"domain"`
+	GenearlSummary VulnerabilityGeneralSummary `json:"general_summary"`
+}
+
+type VulnerabilityGeneralSummary struct {
+	TotalVulnerabilities      int                       `json:"total_vulnerabilites"`
+	SeverityCounts            tools.SeverityCounts      `json:"severity_counts,omitempty"`
+	VulnerabilitiesByCategory VulnerabilitiesByCategory `json:"vulnerabilities_by_category"`
+	VulnerabilityTrends       VulnerabilityTrends       `json:"vulnerability_trends"`
+}
+
+type VulnerabilitiesByCategory struct {
+	CategoryData []CategoryData `json:"category_data"`
+}
+
+type CategoryData struct {
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+}
+
+type VulnerabilityTrends struct {
+	TimePeriods               []TimePeriod `json:"time_periods"`
+	AverageVulnerabilityCount float64      `json:"average_vlnearbility_count"`
+}
+
+type TimePeriod struct {
+	TimePeriod         string `json:"time_period"`
+	VulnerabilityCount int    `json:"vulnerability_count"`
 }

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -147,3 +147,14 @@ func (h *ScanHandlers) GetScanInsightsByID(w http.ResponseWriter, r *http.Reques
 
 	return api.WriteJSON(w, http.StatusOK, summary)
 }
+
+func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r *http.Request) error {
+	scanID, err := GetUUID(r)
+	if err != nil {
+		slog.Error("failed to extract scanID", slog.Any("err", err))
+	}
+	var summary ScanVulnerabilitySummaryResponse
+
+	slog.Debug("Fetching scan vulnerabilities summary...", slog.String("scan_id", scanID.String()))
+	return api.WriteJSON(w, http.StatusOK, summary)
+}

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -154,7 +155,33 @@ func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r 
 		slog.Error("failed to extract scanID", slog.Any("err", err))
 	}
 
-	summaryData, err := h.scanService.GetScanVulnerabilitySummaryByID(scanID)
+	timePeriodFilter := r.URL.Query().Get("time_period")
+	validTimePeriods := map[string]bool{"Month": true, "Quarter": true, "Semester": true}
+	if !validTimePeriods[timePeriodFilter] {
+		slog.Warn("Invalid time_period filter",
+			slog.String("time_period_filter", timePeriodFilter))
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
+	}
+
+	severityFilterStr := r.URL.Query().Get("severity")
+	var severityFilters []string
+	if severityFilterStr != "" {
+		severityFilters = strings.Split(severityFilterStr, ",")
+		validSeverities := map[string]bool{
+			"low":      true,
+			"medium":   true,
+			"high":     true,
+			"critical": true,
+		}
+		for i, severity := range severityFilters {
+			if !validSeverities[strings.ToLower(severity)] {
+				return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid severity filter. Allowed values: Critical,High,Medium,Low"})
+			}
+			severityFilters[i] = strings.ToLower(severity)
+		}
+	}
+
+	summaryData, err := h.scanService.GetScanVulnerabilitySummaryByID(scanID, timePeriodFilter, severityFilters)
 	if err != nil {
 		slog.Error("failed to get scan vulnerabilities summary",
 			slog.String("scan_id", scanID.String()),

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -153,8 +153,35 @@ func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r 
 	if err != nil {
 		slog.Error("failed to extract scanID", slog.Any("err", err))
 	}
-	var summary ScanVulnerabilitySummaryResponse
 
-	slog.Debug("Fetching scan vulnerabilities summary...", slog.String("scan_id", scanID.String()))
-	return api.WriteJSON(w, http.StatusOK, summary)
+	summaryData, err := h.scanService.GetScanVulnerabilitySummaryByID(scanID)
+	if err != nil {
+		slog.Error("failed to get scan vulnerabilities summary",
+			slog.String("scan_id", scanID.String()),
+			slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+	}
+
+	if summaryData == nil {
+		return api.WriteJSON(w, http.StatusNotFound, api.APIError{Error: "Scan summary not found"})
+	}
+
+	// Map from service layer struct to API response DTO
+	response := ScanVulnerabilitySummaryResponse{
+		ScanID: summaryData.ScanID.String(),
+		Domain: summaryData.Domain,
+		GeneralSummary: VulnerabilityGeneralSummary{
+			TotalVulnerabilities: summaryData.TotalVulnerabilities,
+			SeverityCounts:       summaryData.SeverityCounts,
+			VulnerabilitiesByCategory: VulnerabilitiesByCategory{
+				CategoryData: adaptCategoryData(summaryData.CategoryData),
+			},
+			VulnerabilityTrends: VulnerabilityTrends{
+				TimePeriods:               adaptTimePeriods(summaryData.VulnerabilityTrends.TimePeriods),
+				AverageVulnerabilityCount: summaryData.VulnerabilityTrends.AverageVulnerabilityCount,
+			},
+		},
+	}
+
+	return api.WriteJSON(w, http.StatusOK, response)
 }

--- a/pkg/interfaces/scan.go
+++ b/pkg/interfaces/scan.go
@@ -20,6 +20,7 @@ type IScanService interface {
 	CalculateProtectionScore(scanID uuid.UUID) (float64, error)
 	GetScanByID(scanID uuid.UUID) (*domain.Scan, error)
 	HandleScanCompletion(scanID uuid.UUID) error
+	GetScanVulnerabilitySummaryByID(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error)
 }
 
 type IScanHandlers interface {

--- a/pkg/interfaces/scan.go
+++ b/pkg/interfaces/scan.go
@@ -20,7 +20,7 @@ type IScanService interface {
 	CalculateProtectionScore(scanID uuid.UUID) (float64, error)
 	GetScanByID(scanID uuid.UUID) (*domain.Scan, error)
 	HandleScanCompletion(scanID uuid.UUID) error
-	GetScanVulnerabilitySummaryByID(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error)
+	GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 }
 
 type IScanHandlers interface {

--- a/pkg/interfaces/scan.go
+++ b/pkg/interfaces/scan.go
@@ -27,4 +27,5 @@ type IScanHandlers interface {
 	GetScans(writer http.ResponseWriter, request *http.Request) error
 	CancelScanByID(w http.ResponseWriter, r *http.Request) error
 	GetScanInsightsByID(w http.ResponseWriter, r *http.Request) error
+	GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r *http.Request) error
 }

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -33,4 +33,5 @@ type IStorage interface {
 	GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error)
 	GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error)
 	GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error)
+	GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error)
 }

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -33,5 +33,5 @@ type IStorage interface {
 	GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error)
 	GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error)
 	GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error)
-	GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error)
+	GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 }

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -192,36 +192,14 @@ func (s *ScanService) HandleScanCompletion(scanID uuid.UUID) error {
 	return nil
 }
 
-func (s *ScanService) GetScanVulnerabilitySummaryByID(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error) {
+func (s *ScanService) GetScanVulnerabilitySummaryByID(
+	scanID uuid.UUID,
+	timePeriodFilter string,
+	severityFilters []string,
+) (*domain.ScanVulnerabilitySummaryData, error) {
 	slog.Debug("Fetching scan vulnerabilities summary...", slog.String("scan_id", scanID.String()))
 
-	// summaryData := &domain.ScanVulnerabilitySummaryData{
-	// 	ScanID:               scanID,
-	// 	Domain:               "example.com",
-	// 	TotalVulnerabilities: 150,
-	// 	SeverityCounts: tools.SeverityCounts{
-	// 		Critical: 10,
-	// 		High:     30,
-	// 		Medium:   50,
-	// 		Low:      40,
-	// 	},
-	// 	CategoryData: []domain.ServiceCategoryData{
-	// 		{Category: "XSS", Count: 15},
-	// 		{Category: "SQL Injection", Count: 20},
-	// 		{Category: "CSRF", Count: 7},
-	// 	},
-	// 	VulnerabilityTrends: domain.ServiceVulnerabilityTrends{
-	// 		TimePeriods: []domain.ServiceTimePeriod{
-	// 			{TimePeriod: "Jan", VulnerabilityCount: 25},
-	// 			{TimePeriod: "Feb", VulnerabilityCount: 30},
-	// 			{TimePeriod: "Mar", VulnerabilityCount: 40},
-	// 		},
-	// 		AverageVulnerabilityCount: 65.4,
-	// 	},
-	// }
-	//
-
-	summaryData, err := s.storage.GetScanVulnerabilitiesSummary(scanID)
+	summaryData, err := s.storage.GetScanVulnerabilitiesSummary(scanID, timePeriodFilter, severityFilters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch vulnerabilities summary: %w", err)
 	}

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/results"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/common/common/pkg/utils/validation"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -190,4 +191,33 @@ func (s *ScanService) HandleScanCompletion(scanID uuid.UUID) error {
 	}
 
 	return nil
+}
+
+func (s *ScanService) GetScanVulnerabilitySummaryByID(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error) {
+	summaryData := &domain.ScanVulnerabilitySummaryData{
+		ScanID:               scanID,
+		Domain:               "example.com",
+		TotalVulnerabilities: 150,
+		SeverityCounts: tools.SeverityCounts{
+			Critical: 10,
+			High:     30,
+			Medium:   50,
+			Low:      40,
+		},
+		CategoryData: []domain.ServiceCategoryData{
+			{Category: "XSS", Count: 15},
+			{Category: "SQL Injection", Count: 20},
+			{Category: "CSRF", Count: 7},
+		},
+		VulnerabilityTrends: domain.ServiceVulnerabilityTrends{
+			TimePeriods: []domain.ServiceTimePeriod{
+				{TimePeriod: "Jan", VulnerabilityCount: 25},
+				{TimePeriod: "Feb", VulnerabilityCount: 30},
+				{TimePeriod: "Mar", VulnerabilityCount: 40},
+			},
+			AverageVulnerabilityCount: 65.4,
+		},
+	}
+
+	return summaryData, nil
 }

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/results"
-	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/common/common/pkg/utils/validation"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -194,29 +193,37 @@ func (s *ScanService) HandleScanCompletion(scanID uuid.UUID) error {
 }
 
 func (s *ScanService) GetScanVulnerabilitySummaryByID(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error) {
-	summaryData := &domain.ScanVulnerabilitySummaryData{
-		ScanID:               scanID,
-		Domain:               "example.com",
-		TotalVulnerabilities: 150,
-		SeverityCounts: tools.SeverityCounts{
-			Critical: 10,
-			High:     30,
-			Medium:   50,
-			Low:      40,
-		},
-		CategoryData: []domain.ServiceCategoryData{
-			{Category: "XSS", Count: 15},
-			{Category: "SQL Injection", Count: 20},
-			{Category: "CSRF", Count: 7},
-		},
-		VulnerabilityTrends: domain.ServiceVulnerabilityTrends{
-			TimePeriods: []domain.ServiceTimePeriod{
-				{TimePeriod: "Jan", VulnerabilityCount: 25},
-				{TimePeriod: "Feb", VulnerabilityCount: 30},
-				{TimePeriod: "Mar", VulnerabilityCount: 40},
-			},
-			AverageVulnerabilityCount: 65.4,
-		},
+	slog.Debug("Fetching scan vulnerabilities summary...", slog.String("scan_id", scanID.String()))
+
+	// summaryData := &domain.ScanVulnerabilitySummaryData{
+	// 	ScanID:               scanID,
+	// 	Domain:               "example.com",
+	// 	TotalVulnerabilities: 150,
+	// 	SeverityCounts: tools.SeverityCounts{
+	// 		Critical: 10,
+	// 		High:     30,
+	// 		Medium:   50,
+	// 		Low:      40,
+	// 	},
+	// 	CategoryData: []domain.ServiceCategoryData{
+	// 		{Category: "XSS", Count: 15},
+	// 		{Category: "SQL Injection", Count: 20},
+	// 		{Category: "CSRF", Count: 7},
+	// 	},
+	// 	VulnerabilityTrends: domain.ServiceVulnerabilityTrends{
+	// 		TimePeriods: []domain.ServiceTimePeriod{
+	// 			{TimePeriod: "Jan", VulnerabilityCount: 25},
+	// 			{TimePeriod: "Feb", VulnerabilityCount: 30},
+	// 			{TimePeriod: "Mar", VulnerabilityCount: 40},
+	// 		},
+	// 		AverageVulnerabilityCount: 65.4,
+	// 	},
+	// }
+	//
+
+	summaryData, err := s.storage.GetScanVulnerabilitiesSummary(scanID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch vulnerabilities summary: %w", err)
 	}
 
 	return summaryData, nil

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -182,10 +183,10 @@ func (s *PostgreSQLStore) GetScans(tenantID string) ([]*domain.ScanSummary, erro
     SELECT
       S.id AS scan_id,
       COUNT(V.id) AS total_vulnerabilities,
-      SUM(CASE WHEN V.cvss < 4.0 THEN 1 ELSE 0 END) AS low,
-      SUM(CASE WHEN V.cvss >= 4.0 AND V.cvss < 7.0 THEN 1 ELSE 0 END) as medium,
-      SUM(CASE WHEN V.cvss >= 7.0 AND V.cvss < 9.0 THEN 1 ELSE 0 END) as high,
-      SUM(CASE WHEN V.cvss >= 9.0 THEN 1 ELSE 0 END) AS critical
+      SUM(CASE WHEN V.severity = 'Low' THEN 1 ELSE 0 END) AS low,
+      SUM(CASE WHEN V.severity = 'Medium' THEN 1 ELSE 0 END) as medium,
+      SUM(CASE WHEN V.severity = 'High' THEN 1 ELSE 0 END) as high,
+      SUM(CASE WHEN V.severity = 'Critical' THEN 1 ELSE 0 END) AS critical
     FROM scans S
     LEFT JOIN scan_vulnerabilities V ON S.id = V.scan_id
     WHERE S.tenant_id = $1
@@ -377,10 +378,10 @@ func (s *PostgreSQLStore) GetScanInsights(scanID uuid.UUID) (*domain.ScanInsight
       hosts.alias AS scan_alias,
       scans.started_at AS scan_date,
       COUNT(sv.id) AS total_vulnerabilities,
-      SUM(CASE WHEN sv.cvss < 4.0 THEN 1 ELSE 0 END) AS low_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 4.0 AND sv.cvss < 7.0 THEN 1 ELSE 0 END) as medium_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 7.0 AND sv.cvss < 9.0 THEN 1 ELSE 0 END) as high_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 9.0 THEN 1 ELSE 0 END) AS critical_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'Low' THEN 1 ELSE 0 END) AS low_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'Medium' THEN 1 ELSE 0 END) as medium_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'High' THEN 1 ELSE 0 END) as high_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'Critical' THEN 1 ELSE 0 END) AS critical_vulnerabilities,
       (
         SELECT json_object_agg(
           vuln_type,
@@ -636,30 +637,40 @@ func (s *PostgreSQLStore) UpdateProtectionScore(scanID uuid.UUID, protectionScor
 	return nil
 }
 
-func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error) {
-	// TODO: Add timePeriod filter logic
-	// TODO: Add severity filter logic
+func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(
+	scanID uuid.UUID,
+	timePeriodFilter string,
+	severityFilters []string,
+) (*domain.ScanVulnerabilitySummaryData, error) {
 	var summaryData domain.ScanVulnerabilitySummaryData
 	// 1. Get vulnerabilities
-	query := `
+	baseSummaryQuery := `
     SELECT 
       scans.id AS scan_id,
       hosts.alias AS host_alias,
       COUNT(sv.id) AS total_vulnerabilities,
-      SUM(CASE WHEN sv.cvss < 4.0 THEN 1 ELSE 0 END) AS low_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 4.0 AND sv.cvss < 7.0 THEN 1 ELSE 0 END) as medium_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 7.0 AND sv.cvss < 9.0 THEN 1 ELSE 0 END) as high_vulnerabilities,
-      SUM(CASE WHEN sv.cvss >= 9.0 THEN 1 ELSE 0 END) AS critical_vulnerabilities
+      SUM(CASE WHEN sv.severity = 'Low' THEN 1 ELSE 0 END) AS low_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'Medium' THEN 1 ELSE 0 END) as medium_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'High' THEN 1 ELSE 0 END) as high_vulnerabilities,
+      SUM(CASE WHEN sv.severity = 'Critical' THEN 1 ELSE 0 END) AS critical_vulnerabilities
   FROM
     scans
   INNER JOIN hosts ON scans.host_id = hosts.id
   LEFT JOIN
     scan_vulnerabilities sv ON scans.id = sv.scan_id
   WHERE scans.id = $1
+    -- Severity Filter Dynamic Condition goes here
+    %s
   GROUP BY scans.id, hosts.alias;
   `
 
-	err := s.db.QueryRow(query, scanID).Scan(
+	summaryQueryParams := []any{scanID}
+	summarySeverityWhereClause, summaryQueryParams := s.buildSeverityWhereClause(severityFilters, summaryQueryParams)
+	formattedSummaryQuery := fmt.Sprintf(baseSummaryQuery, summarySeverityWhereClause)
+	slog.Debug("Executing Summary Query",
+		slog.Any("query_params", summaryQueryParams))
+
+	err := s.db.QueryRow(formattedSummaryQuery, summaryQueryParams...).Scan(
 		&summaryData.ScanID,
 		&summaryData.Domain,
 		&summaryData.TotalVulnerabilities,
@@ -678,17 +689,25 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*doma
 
 	// Handling Categories and Trends
 	// 1. Fetch category data
-	categoryQuery := `
+	baseCategoryQuery := `
     SELECT
       sv.type AS category,
-      COUNT(sv.type) AS cateogry_count
+      COUNT(sv.type) AS category_count
     FROM 
       scan_vulnerabilities sv
     WHERE sv.scan_id = $1
+    -- Severity Filter Dynamic Condition goes here
+    %s
     GROUP BY sv.type;
   `
 
-	categoryRows, err := s.db.Query(categoryQuery, scanID)
+	categoryQueryParams := []any{scanID}
+	categorySeverityWhereClause, categoryQueryParams := s.buildSeverityWhereClause(severityFilters, categoryQueryParams)
+	formattedCategoryQuery := fmt.Sprintf(baseCategoryQuery, categorySeverityWhereClause)
+	slog.Debug("Executing Category Query",
+		slog.Any("query_params", categoryQueryParams))
+
+	categoryRows, err := s.db.Query(formattedCategoryQuery, categoryQueryParams...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query vulnerability categories: %w", err)
 	}
@@ -712,7 +731,7 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*doma
 	// This query is kind of complicated, but what it does is fill out time_periods and labels,
 	// even when there is no data for said time_period. E.g: we only have data
 	// for February, but we want to have the counts for other months to be 0 too.
-	trendQuery := `
+	baseTrendQuery := `
   WITH TimePeriods as (
   SELECT 
         CASE 
@@ -750,6 +769,8 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*doma
       FROM scan_vulnerabilities sv
       WHERE sv.scan_id = $1
         AND EXTRACT(YEAR FROM sv.created_at) = EXTRACT(YEAR FROM CURRENT_DATE)
+          -- Severity Filter Dynamic Condition goes here
+          %s
       GROUP BY time_period_label
   )
   SELECT 
@@ -760,10 +781,13 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*doma
   ORDER BY tp.ordering_period;
 `
 
-	// TODO: Change this for method filter
-	timePeriodMonth := "Month"
+	trendQueryParams := []any{scanID, timePeriodFilter}
+	trendSeverityWhereClause, trendQueryParams := s.buildSeverityWhereClause(severityFilters, trendQueryParams)
+	formattedTrendQuery := fmt.Sprintf(baseTrendQuery, trendSeverityWhereClause)
+	slog.Debug("Executing Summary Query",
+		slog.Any("query_params", trendQueryParams))
 
-	trendsRows, err := s.db.Query(trendQuery, scanID, timePeriodMonth)
+	trendsRows, err := s.db.Query(formattedTrendQuery, trendQueryParams...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query vulnerability trends: %w", err)
 	}
@@ -795,4 +819,18 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*doma
 	summaryData.VulnerabilityTrends = vulnerabilityTrends
 
 	return &summaryData, nil
+}
+
+func (s *PostgreSQLStore) buildSeverityWhereClause(severityFilters []string, queryParams []any) (string, []any) {
+	severityWhereClause := ""
+	if len(severityFilters) > 0 {
+		placeholders := make([]string, len(severityFilters))
+		for i, severity := range severityFilters {
+			placeholders[i] = fmt.Sprintf("$%d", len(queryParams)+1)
+			queryParams = append(queryParams, severity)
+		}
+		severityWhereClause = fmt.Sprintf("AND sv.severity ILIKE ANY(array[%s])", strings.Join(placeholders, ","))
+	}
+
+	return severityWhereClause, queryParams
 }

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -643,6 +643,7 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(
 	severityFilters []string,
 ) (*domain.ScanVulnerabilitySummaryData, error) {
 	var summaryData domain.ScanVulnerabilitySummaryData
+	summaryData.ScanID = scanID
 	// 1. Get vulnerabilities
 	baseSummaryQuery := `
     SELECT 
@@ -682,7 +683,7 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			slog.Warn("No rows were found", slog.String("scan_id", scanID.String()))
-			return nil, nil
+			return &summaryData, nil
 		}
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -635,3 +635,164 @@ func (s *PostgreSQLStore) UpdateProtectionScore(scanID uuid.UUID, protectionScor
 	}
 	return nil
 }
+
+func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(scanID uuid.UUID) (*domain.ScanVulnerabilitySummaryData, error) {
+	// TODO: Add timePeriod filter logic
+	// TODO: Add severity filter logic
+	var summaryData domain.ScanVulnerabilitySummaryData
+	// 1. Get vulnerabilities
+	query := `
+    SELECT 
+      scans.id AS scan_id,
+      hosts.alias AS host_alias,
+      COUNT(sv.id) AS total_vulnerabilities,
+      SUM(CASE WHEN sv.cvss < 4.0 THEN 1 ELSE 0 END) AS low_vulnerabilities,
+      SUM(CASE WHEN sv.cvss >= 4.0 AND sv.cvss < 7.0 THEN 1 ELSE 0 END) as medium_vulnerabilities,
+      SUM(CASE WHEN sv.cvss >= 7.0 AND sv.cvss < 9.0 THEN 1 ELSE 0 END) as high_vulnerabilities,
+      SUM(CASE WHEN sv.cvss >= 9.0 THEN 1 ELSE 0 END) AS critical_vulnerabilities
+  FROM
+    scans
+  INNER JOIN hosts ON scans.host_id = hosts.id
+  LEFT JOIN
+    scan_vulnerabilities sv ON scans.id = sv.scan_id
+  WHERE scans.id = $1
+  GROUP BY scans.id, hosts.alias;
+  `
+
+	err := s.db.QueryRow(query, scanID).Scan(
+		&summaryData.ScanID,
+		&summaryData.Domain,
+		&summaryData.TotalVulnerabilities,
+		&summaryData.SeverityCounts.Low,
+		&summaryData.SeverityCounts.Medium,
+		&summaryData.SeverityCounts.High,
+		&summaryData.SeverityCounts.Critical,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("No rows were found", slog.String("scan_id", scanID.String()))
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	// Handling Categories and Trends
+	// 1. Fetch category data
+	categoryQuery := `
+    SELECT
+      sv.type AS category,
+      COUNT(sv.type) AS cateogry_count
+    FROM 
+      scan_vulnerabilities sv
+    WHERE sv.scan_id = $1
+    GROUP BY sv.type;
+  `
+
+	categoryRows, err := s.db.Query(categoryQuery, scanID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query vulnerability categories: %w", err)
+	}
+	defer categoryRows.Close()
+
+	var categoryData []domain.ServiceCategoryData
+	for categoryRows.Next() {
+		var catData domain.ServiceCategoryData
+		if err := categoryRows.Scan(&catData.Category, &catData.Count); err != nil {
+			return nil, fmt.Errorf("failed to scan into category data: %w", err)
+		}
+		categoryData = append(categoryData, catData)
+	}
+	if err := categoryRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate category rows: %w", err)
+	}
+
+	summaryData.CategoryData = categoryData
+
+	// 2. Fetch trend data
+	// This query is kind of complicated, but what it does is fill out time_periods and labels,
+	// even when there is no data for said time_period. E.g: we only have data
+	// for February, but we want to have the counts for other months to be 0 too.
+	trendQuery := `
+  WITH TimePeriods as (
+  SELECT 
+        CASE 
+          WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'FMMonth')
+          WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(date_series, 'Q')
+          WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+          ELSE 'Unknown Period'
+        END AS time_period_label,
+        CASE
+          WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'YYYY-MM')
+          WHEN $2 = 'Quarter' THEN TO_CHAR(date_series, 'YYYY-Q')
+          WHEN $2 = 'Semester' THEN CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+          ELSE '1'
+        END AS ordering_period
+      FROM generate_series(
+        DATE_TRUNC('year', CURRENT_DATE),
+        DATE_TRUNC('year', CURRENT_DATE) + INTERVAL '1 year' - INTERVAL '1 day',
+        CASE
+          WHEN $2 = 'Month' THEN INTERVAL '1 month'
+          WHEN $2 = 'Quarter' THEN INTERVAL '3 month'
+          WHEN $2 = 'Semester' THEN INTERVAL '6 month'
+          ELSE INTERVAL '1 month'
+        END
+      ) AS date_series
+  ),
+  VulnerabilityCounts AS (
+  SELECT
+          CASE
+              WHEN $2 = 'Month' THEN TO_CHAR(sv.created_at, 'FMMonth')
+              WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(sv.created_at, 'Q')
+              WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(sv.created_at, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+              ELSE 'Unknown Period'
+          END AS time_period_label,
+          COUNT(sv.id) AS vulnerability_count
+      FROM scan_vulnerabilities sv
+      WHERE sv.scan_id = $1
+        AND EXTRACT(YEAR FROM sv.created_at) = EXTRACT(YEAR FROM CURRENT_DATE)
+      GROUP BY time_period_label
+  )
+  SELECT 
+    tp.time_period_label AS time_period,
+    COALESCE(vc.vulnerability_count, 0) AS vulnerability_count
+  FROM TimePeriods tp
+  LEFT JOIN VulnerabilityCounts vc ON tp.time_period_label = vc.time_period_label
+  ORDER BY tp.ordering_period;
+`
+
+	// TODO: Change this for method filter
+	timePeriodMonth := "Month"
+
+	trendsRows, err := s.db.Query(trendQuery, scanID, timePeriodMonth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query vulnerability trends: %w", err)
+	}
+	defer trendsRows.Close()
+
+	var vulnerabilityTrends domain.ServiceVulnerabilityTrends
+	var timePeriods []domain.ServiceTimePeriod
+	var totalVulnCountForAvg, periodCountForAvg float64
+	for trendsRows.Next() {
+		var timePeriodData domain.ServiceTimePeriod
+		if err := trendsRows.Scan(&timePeriodData.TimePeriod, &timePeriodData.VulnerabilityCount); err != nil {
+			return nil, fmt.Errorf("failed to scan into time period: %w", err)
+		}
+		timePeriods = append(timePeriods, timePeriodData)
+		totalVulnCountForAvg += float64(timePeriodData.VulnerabilityCount)
+		periodCountForAvg++
+	}
+	if err := trendsRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate trend rows: %w", err)
+	}
+
+	vulnerabilityTrends.TimePeriods = timePeriods
+	if periodCountForAvg > 0 {
+		vulnerabilityTrends.AverageVulnerabilityCount = totalVulnCountForAvg / periodCountForAvg
+	} else {
+		vulnerabilityTrends.AverageVulnerabilityCount = 0.0
+	}
+
+	summaryData.VulnerabilityTrends = vulnerabilityTrends
+
+	return &summaryData, nil
+}

--- a/pkg/storage/scan_test.go
+++ b/pkg/storage/scan_test.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestPostgreSQLStore_buildSeverityWhereClause(t *testing.T) {
+	tests := []struct {
+		name            string
+		severityFilters []string
+		queryParams     []any
+		wantQuery       string
+		wantParams      []any
+	}{
+		{
+			name:            "No severity filters or query params",
+			severityFilters: []string{},
+			queryParams:     []any{},
+			wantQuery:       "",
+			wantParams:      []any{},
+		},
+		{
+			name:            "Single severity filter",
+			severityFilters: []string{"critical"},
+			queryParams:     []any{},
+			wantQuery:       "AND sv.severity ILIKE ANY(array[$1])",
+			wantParams:      []any{"critical"},
+		},
+		{
+			name:            "Multiple severity filters",
+			severityFilters: []string{"critical", "high"},
+			queryParams:     []any{},
+			wantQuery:       "AND sv.severity ILIKE ANY(array[$1,$2])",
+			wantParams:      []any{"critical", "high"},
+		},
+		{
+			name:            "Two severity Filters and two query Params",
+			severityFilters: []string{"critical", "high"},
+			queryParams: []any{
+				uuid.MustParse("515a7031-af4e-4661-9c18-603da9931db8"),
+				"Month",
+			},
+			wantQuery: "AND sv.severity ILIKE ANY(array[$3,$4])",
+			wantParams: []any{
+				uuid.MustParse("515a7031-af4e-4661-9c18-603da9931db8"),
+				"Month",
+				"critical",
+				"high",
+			},
+		},
+		{
+			name:            "Multiple severity filters with special characters",
+			severityFilters: []string{"CRITICAL", "higH"},
+			queryParams:     []any{},
+			wantQuery:       "AND sv.severity ILIKE ANY(array[$1,$2])",
+			wantParams:      []any{"CRITICAL", "higH"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock
+			s := &PostgreSQLStore{}
+
+			gotQuery, gotParams := s.buildSeverityWhereClause(tt.severityFilters, tt.queryParams)
+			if gotQuery != tt.wantQuery {
+				t.Errorf("buildSeverityWhereClause() = %v, want %v", gotQuery, tt.wantQuery)
+			}
+			if !reflect.DeepEqual(gotParams, tt.wantParams) {
+				t.Errorf("buildSeverityWhereClause() = %v, want %v", gotParams, tt.wantParams)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🔄 Service & Handler Layer
- Implemented `GET api/scans/{id}/vulnerabilities/summary` endpoint ([documentation here](https://kptmtools.docs.apiary.io/#/reference/0/summary-of-a-scans-vulnerabilities)) and storage logic for calculating a vulnerability summary.
- Implemented endpoint _logic for filtering_ the vulnerabilities in said summary by `time_period` (Month, Semester, Quarter) and `severity`.

## 💾 Storage Layer 
- Added migrations for adding a "severity" column into the vulnerability table, which simplifies aggregated queries
   - refactored storage methods to use this column
- Added migrations for a trigger that calculates the severity column on INSERT or UPDATE