### PR TITLE
Feature/kt 319 implement reports endpoint

### DIFF
--- a/cmd/migrations/migrations/000014_add_analyst_comment_to_scan_vulnerabilities.down.sql
+++ b/cmd/migrations/migrations/000014_add_analyst_comment_to_scan_vulnerabilities.down.sql
@@ -1,0 +1,3 @@
+-- Migration: 000014_add_analyst_comment_to_scan_vulnerabilities.down.sql
+ALTER TABLE scan_vulnerabilities
+DROP COLUMN analyst_comment;

--- a/cmd/migrations/migrations/000014_add_analyst_comment_to_scan_vulnerabilities.up.sql
+++ b/cmd/migrations/migrations/000014_add_analyst_comment_to_scan_vulnerabilities.up.sql
@@ -1,0 +1,3 @@
+-- Migration: 000014_add_analyst_comment_to_scan_vulnerabilities.up.sql
+ALTER TABLE scan_vulnerabilities
+ADD COLUMN analyst_comment TEXT NULL;

--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,15 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/likexian/gokit v0.25.15 // indirect
 	github.com/nats-io/nkeys v0.4.9 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
@@ -34,4 +37,5 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -78,6 +78,8 @@ func (s *APIServer) Init() error {
 	router.HandleFunc("GET /api/scans/{id}/insights", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScanInsightsByID), "getScanInsightsByID"))
 	router.HandleFunc("GET /api/scans/{id}/vulnerabilities/summary", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScanVulnerabilitySummaryByID), "getScanVulnerabilitySummaryByID"))
 
+	router.HandleFunc("GET /api/reports", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetReports), "getAllTenantReports"))
+
 	stack := middleware.CreateStack(
 		middleware.Logging,
 		middleware.CheckCORS,

--- a/pkg/domain/report.go
+++ b/pkg/domain/report.go
@@ -1,0 +1,23 @@
+package domain
+
+import "time"
+
+type CommmentStatus string
+
+const (
+	CommentStatusPending    CommmentStatus = "PENDING"
+	CommentStatusNewComment CommmentStatus = "NEW COMMENT"
+	CommentStatusCritical   CommmentStatus = "CRITICAL"
+)
+
+func (cs CommmentStatus) String() string {
+	return string(cs)
+}
+
+type ReportItem struct {
+	HostName        string         `json:"host_name"`
+	IP              string         `json:"ip"`
+	ScanDate        time.Time      `json:"scan_date"`
+	TotalSeverities int            `json:"total_severities"`
+	CommentStatus   CommmentStatus `json:"comment_status"`
+}

--- a/pkg/domain/report.go
+++ b/pkg/domain/report.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type CommmentStatus string
 
@@ -15,6 +19,7 @@ func (cs CommmentStatus) String() string {
 }
 
 type ReportItem struct {
+	ScanID          uuid.UUID      `json:"scan_id"`
 	HostName        string         `json:"host_name"`
 	IP              string         `json:"ip"`
 	ScanDate        time.Time      `json:"scan_date"`

--- a/pkg/domain/report.go
+++ b/pkg/domain/report.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +17,19 @@ const (
 
 func (cs CommmentStatus) String() string {
 	return string(cs)
+}
+
+func ParseCommentStatus(statusString string) (CommmentStatus, error) {
+	switch statusString {
+	case "PENDING":
+		return CommentStatusPending, nil
+	case "NEW COMMENT":
+		return CommentStatusNewComment, nil
+	case "CRITICAL":
+		return CommentStatusCritical, nil
+	default:
+		return "", fmt.Errorf("invalid comment status string: %s", statusString)
+	}
 }
 
 type ReportItem struct {

--- a/pkg/domain/report_test.go
+++ b/pkg/domain/report_test.go
@@ -1,0 +1,80 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseCommentStatus_ValidStatuses(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputString    string
+		expectedStatus CommmentStatus
+	}{
+		{
+			name:           "Valid PENDING",
+			inputString:    "PENDING",
+			expectedStatus: CommentStatusPending,
+		},
+		{
+			name:           "Valid NEW COMMENT",
+			inputString:    "NEW COMMENT",
+			expectedStatus: CommentStatusNewComment,
+		},
+		{
+			name:           "Valid CRITICAL",
+			inputString:    "CRITICAL",
+			expectedStatus: CommentStatusCritical,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := ParseCommentStatus(tc.inputString)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedStatus, status)
+		})
+	}
+}
+
+func Test_ParseCommentStatus_InvalidStatuses(t *testing.T) {
+	testCases := []struct {
+		name        string
+		inputString string
+	}{
+		{
+			name:        "Empty String",
+			inputString: "",
+		},
+		{
+			name:        "Invalid Status Lowercase",
+			inputString: "pending",
+		},
+		{
+			name:        "Invalid Status Mixed Case",
+			inputString: "New Comment",
+		},
+		{
+			name:        "Invalid Status Extra Space",
+			inputString: "CRITICAL ",
+		},
+		{
+			name:        "Completely Invalid",
+			inputString: "THIS_IS_NOT_A_STATUS",
+		},
+		{
+			name:        "Number",
+			inputString: "123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := ParseCommentStatus(tc.inputString)
+			assert.Error(t, err)
+			assert.Equal(t, CommmentStatus(""), status, "Expected empty comment status for invalid input")
+			assert.Contains(t, err.Error(), "invalid comment status string")
+		})
+	}
+}

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -62,6 +62,7 @@ func GetValidRoles(funcName string) ([]Role, error) {
 		"cancelScanByID":                  {RoleOperator},
 		"getScanInsightsByID":             {RoleOperator, RoleAnalyst},
 		"getScanVulnerabilitySummaryByID": {RoleOperator, RoleAnalyst},
+		"getAllTenantReports":             {RoleOperator, RoleAnalyst},
 	}
 
 	v, ok := funcRoles[funcName]

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
 )
@@ -62,4 +64,12 @@ func adaptTimePeriods(serviceTimePeriodData []domain.ServiceTimePeriod) []TimePe
 		}
 	}
 	return adaptedData
+}
+
+type ReportsResponse struct {
+	Domain          string    `json:"domain"`
+	IP              string    `json:"ip"`
+	ScanDate        time.Time `json:"scan_date"`
+	TotalSeverities int       `json:"total_severities"`
+	CommentStatus   string    `json:"comment_status"`
 }

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -67,6 +67,7 @@ func adaptTimePeriods(serviceTimePeriodData []domain.ServiceTimePeriod) []TimePe
 }
 
 type ReportsResponse struct {
+	ScanID          string    `json:"scan_id"`
 	Domain          string    `json:"domain"`
 	IP              string    `json:"ip"`
 	ScanDate        time.Time `json:"scan_date"`

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -212,3 +212,28 @@ func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r 
 
 	return api.WriteJSON(w, http.StatusOK, response)
 }
+
+func (h *ScanHandlers) GetReports(w http.ResponseWriter, r *http.Request) error {
+	tenantID := r.Context().Value(middleware.ContextTenantID).(string)
+
+	reportItems, err := h.scanService.GetAllReportsForTenant(tenantID)
+	if err != nil {
+		slog.Error("Failed to get all reports for tenant",
+			slog.String("tenant_id", tenantID),
+			slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+	}
+
+	reportResponses := make([]ReportsResponse, len(reportItems))
+	for i, item := range reportItems {
+		reportResponses[i] = ReportsResponse{
+			Domain:          item.HostName,
+			IP:              item.IP,
+			ScanDate:        item.ScanDate,
+			TotalSeverities: item.TotalSeverities,
+			CommentStatus:   item.CommentStatus.String(),
+		}
+	}
+
+	return api.WriteJSON(w, http.StatusOK, reportResponses)
+}

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -227,6 +227,7 @@ func (h *ScanHandlers) GetReports(w http.ResponseWriter, r *http.Request) error 
 	reportResponses := make([]ReportsResponse, len(reportItems))
 	for i, item := range reportItems {
 		reportResponses[i] = ReportsResponse{
+			ScanID:          item.ScanID.String(),
 			Domain:          item.HostName,
 			IP:              item.IP,
 			ScanDate:        item.ScanDate,

--- a/pkg/interfaces/scan.go
+++ b/pkg/interfaces/scan.go
@@ -21,6 +21,7 @@ type IScanService interface {
 	GetScanByID(scanID uuid.UUID) (*domain.Scan, error)
 	HandleScanCompletion(scanID uuid.UUID) error
 	GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	GetAllReportsForTenant(tenantID string) ([]*domain.ReportItem, error)
 }
 
 type IScanHandlers interface {
@@ -29,4 +30,5 @@ type IScanHandlers interface {
 	CancelScanByID(w http.ResponseWriter, r *http.Request) error
 	GetScanInsightsByID(w http.ResponseWriter, r *http.Request) error
 	GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r *http.Request) error
+	GetReports(w http.ResponseWriter, r *http.Request) error
 }

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -34,4 +34,5 @@ type IStorage interface {
 	GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error)
 	GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error)
 	GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	GetReportsByTenantID(string) ([]*domain.ReportItem, error)
 }

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -208,23 +208,15 @@ func (s *ScanService) GetScanVulnerabilitySummaryByID(
 }
 
 func (s *ScanService) GetAllReportsForTenant(tenantID string) ([]*domain.ReportItem, error) {
-	// Example dummy data (replace with actual data fetching logic)
-	sampleReports := []*domain.ReportItem{
-		{
-			HostName:        "Google.com",
-			IP:              "60908909",
-			ScanDate:        time.Now().UTC(),
-			TotalSeverities: 40,
-			CommentStatus:   domain.CommentStatusPending,
-		},
-		{
-			HostName:        "facebook.com",
-			IP:              "60908909",
-			ScanDate:        time.Now().UTC(),
-			TotalSeverities: 10,
-			CommentStatus:   domain.CommentStatusNewComment,
-		},
+	reportItems, err := s.storage.GetReportsByTenantID(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch reports from storage: %w", err)
 	}
 
-	return sampleReports, nil
+	// If err is nil and reportItems is nil, it means sql.ErrNoRows was handled in storage
+	if reportItems == nil {
+		return []*domain.ReportItem{}, nil
+	}
+
+	return reportItems, nil
 }

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -206,3 +206,25 @@ func (s *ScanService) GetScanVulnerabilitySummaryByID(
 
 	return summaryData, nil
 }
+
+func (s *ScanService) GetAllReportsForTenant(tenantID string) ([]*domain.ReportItem, error) {
+	// Example dummy data (replace with actual data fetching logic)
+	sampleReports := []*domain.ReportItem{
+		{
+			HostName:        "Google.com",
+			IP:              "60908909",
+			ScanDate:        time.Now().UTC(),
+			TotalSeverities: 40,
+			CommentStatus:   domain.CommentStatusPending,
+		},
+		{
+			HostName:        "facebook.com",
+			IP:              "60908909",
+			ScanDate:        time.Now().UTC(),
+			TotalSeverities: 10,
+			CommentStatus:   domain.CommentStatusNewComment,
+		},
+	}
+
+	return sampleReports, nil
+}

--- a/pkg/services/scan_service_test.go
+++ b/pkg/services/scan_service_test.go
@@ -1,0 +1,284 @@
+package services
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockStorage struct {
+	MockCreateHost                    func(*domain.Host) (*domain.Host, error)
+	MockGetHostsByTenantIDAndUserID   func(string, string) ([]*domain.Host, error)
+	MockGetHostByID                   func(int) (*domain.Host, error)
+	MockDeleteHostByID                func(int) (bool, error)
+	MockPatchHostByID                 func(*domain.Host) (*domain.Host, error)
+	MockCreateTenant                  func(*domain.Tenant) (*domain.Tenant, error)
+	MockGetTenants                    func() ([]*domain.Tenant, error)
+	MockPing                          func() error
+	MockCreateScan                    func(*domain.Scan) (*domain.Scan, error)
+	MockExistAlias                    func(string) (bool, error)
+	MockGetScans                      func(tenantID string) ([]*domain.ScanSummary, error)
+	MockGetScanByID                   func(UUID uuid.UUID) (*domain.Scan, error)
+	MockInsertScanResult              func(*sql.Tx, *domain.ScanResult) error
+	MockInsertVulnerabilityResult     func(*domain.ScanResult) error
+	MockUpdateScanStatus              func(scanID uuid.UUID, status string) error
+	MockUpdateScanStatusAndEndedAt    func(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error
+	MockGetScanInsights               func(scanID uuid.UUID) (*domain.ScanInsights, error)
+	MockGetProtectionScore            func(scanID uuid.UUID) (float64, error)
+	MockUpdateProtectionScore         func(scanID uuid.UUID, score float64) error
+	MockGetWhoisResult                func(scanID uuid.UUID) (*tools.WhoIsResult, error)
+	MockGetDNSLookupResult            func(scanID uuid.UUID) (*tools.DNSLookupResult, error)
+	MockGetHarvesterResult            func(scanID uuid.UUID) (*tools.HarvesterResult, error)
+	MockGetNmapResult                 func(scanID uuid.UUID) (*tools.NmapResult, error)
+	MockGetScanVulnerabilitiesSummary func(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	MockGetReportsByTenantID          func(tenantID string) ([]*domain.ReportItem, error)
+}
+
+func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
+	if m.MockCreateHost != nil {
+		return m.MockCreateHost(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHostsByTenantIDAndUserID(arg0 string, arg1 string) ([]*domain.Host, error) {
+	if m.MockGetHostsByTenantIDAndUserID != nil {
+		return m.MockGetHostsByTenantIDAndUserID(arg0, arg1)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHostByID(arg0 int) (*domain.Host, error) {
+	if m.MockGetHostByID != nil {
+		return m.MockGetHostByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) DeleteHostByID(arg0 int) (bool, error) {
+	if m.MockDeleteHostByID != nil {
+		return m.MockDeleteHostByID(arg0)
+	}
+	return false, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) PatchHostByID(arg0 *domain.Host) (*domain.Host, error) {
+	if m.MockPatchHostByID != nil {
+		return m.MockPatchHostByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) CreateTenant(arg0 *domain.Tenant) (*domain.Tenant, error) {
+	if m.MockCreateTenant != nil {
+		return m.MockCreateTenant(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetTenants() ([]*domain.Tenant, error) {
+	if m.MockGetTenants != nil {
+		return m.MockGetTenants()
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) Ping() error {
+	if m.MockPing != nil {
+		return m.MockPing()
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) CreateScan(arg0 *domain.Scan) (*domain.Scan, error) {
+	if m.MockCreateScan != nil {
+		return m.MockCreateScan(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) ExistAlias(arg0 string) (bool, error) {
+	if m.MockExistAlias != nil {
+		return m.MockExistAlias(arg0)
+	}
+	return false, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScans(tenantID string) ([]*domain.ScanSummary, error) {
+	if m.MockGetScans != nil {
+		return m.MockGetScans(tenantID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanByID(arg0 uuid.UUID) (*domain.Scan, error) {
+	if m.MockGetScanByID != nil {
+		return m.MockGetScanByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) InsertScanResult(arg0 *sql.Tx, arg1 *domain.ScanResult) error {
+	if m.MockInsertScanResult != nil {
+		return m.MockInsertScanResult(arg0, arg1)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) InsertVulnerabilityResult(arg0 *domain.ScanResult) error {
+	if m.MockInsertVulnerabilityResult != nil {
+		return m.MockInsertVulnerabilityResult(arg0)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateScanStatus(scanID uuid.UUID, status string) error {
+	if m.MockUpdateScanStatus != nil {
+		return m.MockUpdateScanStatus(scanID, status)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateScanStatusAndEndedAt(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error {
+	if m.MockUpdateScanStatusAndEndedAt != nil {
+		return m.MockUpdateScanStatusAndEndedAt(tx, scanID, status, endedAt)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanInsights(scanID uuid.UUID) (*domain.ScanInsights, error) {
+	if m.MockGetScanInsights != nil {
+		return m.MockGetScanInsights(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetProtectionScore(scanID uuid.UUID) (float64, error) {
+	if m.MockGetProtectionScore != nil {
+		return m.MockGetProtectionScore(scanID)
+	}
+	return 0, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateProtectionScore(scanID uuid.UUID, score float64) error {
+	if m.MockUpdateProtectionScore != nil {
+		return m.MockUpdateProtectionScore(scanID, score)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetWhoisResult(scanID uuid.UUID) (*tools.WhoIsResult, error) {
+	if m.MockGetWhoisResult != nil {
+		return m.MockGetWhoisResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error) {
+	if m.MockGetDNSLookupResult != nil {
+		return m.MockGetDNSLookupResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error) {
+	if m.MockGetHarvesterResult != nil {
+		return m.MockGetHarvesterResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error) {
+	if m.MockGetNmapResult != nil {
+		return m.MockGetNmapResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
+	if m.MockGetScanVulnerabilitiesSummary != nil {
+		return m.MockGetScanVulnerabilitiesSummary(scanID, timePeriodFilter, severityFilters)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetReportsByTenantID(tenantID string) ([]*domain.ReportItem, error) {
+	if m.MockGetReportsByTenantID != nil {
+		return m.MockGetReportsByTenantID(tenantID)
+	}
+	return nil, nil // Default behaviour if mock function is not set
+}
+
+func Test_GetReportsByTenantID_NoReports(t *testing.T) {
+	mockStore := &MockStorage{
+		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
+			return nil, nil
+		},
+	}
+
+	scansService := NewScanService(mockStore)
+
+	tenantID := "test-tenant"
+	reports, err := scansService.GetAllReportsForTenant(tenantID)
+
+	assert.NoError(t, err)
+	assert.Empty(t, reports)
+}
+
+func Test_GetReportsByTenantID_StorageError(t *testing.T) {
+	mockStore := &MockStorage{
+		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
+			return nil, errors.New("database connection failed")
+		},
+	}
+
+	scansService := NewScanService(mockStore)
+
+	tenantID := "test-tenant"
+	reports, err := scansService.GetAllReportsForTenant(tenantID)
+
+	assert.Error(t, err)
+	assert.Nil(t, reports)
+	assert.Contains(t, err.Error(), "failed to fetch reports from storage")
+}
+
+func Test_GetReportsByTenantID_Success(t *testing.T) {
+	sampleReports := []*domain.ReportItem{
+		{
+			ScanID:          uuid.New(),
+			HostName:        "example.com",
+			IP:              "1.2.3.4",
+			ScanDate:        time.Now(),
+			TotalSeverities: 10,
+			CommentStatus:   domain.CommentStatusNewComment,
+		},
+		{
+			ScanID:          uuid.New(),
+			HostName:        "example2.com",
+			IP:              "5.6.7.8",
+			ScanDate:        time.Now(),
+			TotalSeverities: 20,
+			CommentStatus:   domain.CommentStatusNewComment,
+		},
+	}
+	mockStore := &MockStorage{
+		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
+			return sampleReports, nil
+		},
+	}
+
+	scansService := NewScanService(mockStore)
+
+	tenantID := "test-tenant"
+	reports, err := scansService.GetAllReportsForTenant(tenantID)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, reports)
+	assert.Equal(t, len(sampleReports), len(reports))
+}

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -848,3 +848,68 @@ func (s *PostgreSQLStore) buildSeverityWhereClause(severityFilters []string, que
 
 	return severityWhereClause, queryParams
 }
+
+func (s *PostgreSQLStore) GetReportsByTenantID(tenantID string) ([]*domain.ReportItem, error) {
+	query := `
+  SELECT
+    s.id AS scan_id,
+    h.domain AS host_name,
+    h.ip AS ip,
+    s.started_at as scan_date,
+    (SELECT COUNT(sv.id) FROM scan_vulnerabilities sv WHERE sv.scan_id = s.id) AS total_severities,
+    CASE
+      WHEN NOT EXISTS (
+        SELECT 1
+        FROM scan_vulnerabilities sv
+        WHERE sv.scan_id = s.id
+          AND sv.analyst_comment IS NOT NULL
+      ) THEN 'PENDING' -- CommentStatusPending: No commens on any vulnerability
+      WHEN EXISTS (
+        SELECT 1
+        FROM scan_vulnerabilities sv
+        WHERE sv.scan_id = s.id
+          AND sv.analyst_comment IS NOT NULL
+          AND sv.severity = 'Critical'
+      ) THEN 'CRITICAL' -- CommentStatusCritical: Comment on at least one Critical vulnerability
+      ELSE 'NEW COMMENT' -- CommentStatusNewComment: At least one comment, but no Critical Severity Comments
+    END AS comment_status
+  FROM scans s
+  INNER JOIN hosts h ON s.host_id = h.id
+  `
+
+	rows, err := s.db.Query(query)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // No rows were found
+		}
+		return nil, fmt.Errorf("failed to fetch reports: %w", err)
+	}
+	defer rows.Close()
+
+	reportItems := []*domain.ReportItem{}
+	for rows.Next() {
+		var reportItem domain.ReportItem
+		var commentStatusString string
+		err := rows.Scan(
+			&reportItem.ScanID,
+			&reportItem.HostName,
+			&reportItem.IP,
+			&reportItem.ScanDate,
+			&reportItem.TotalSeverities,
+			&commentStatusString,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan into ReportItem: %w", err)
+		}
+
+		commentStatusEnum, err := domain.ParseCommentStatus(commentStatusString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse comment status string: %w", err)
+		}
+		reportItem.CommentStatus = commentStatusEnum
+
+		reportItems = append(reportItems, &reportItem)
+	}
+
+	return reportItems, nil
+}


### PR DESCRIPTION
## ✨ Features
- Implemented `api/reports` endpoint, which uses scan handlers and scan service.
- Added domain structs for `ReportItem` (for business logic)
- Added DTO struct for `ReportsReponse` (for API resources)
- Implemented storage query to get reports for a given TenantID and parse a vulnerability's comment status.
## 💾 Storage
- Added a simple `TEXT` column to the `scan_vulnerabilities` table called `analyst_comment` for an analyst to post a comment for a certain scan's vulnerability. By default it is `NULL`.
  -  **Reasoning:** Requiements don't currently necessitate anything too complex for comments at the moment (such as comment date, or comment user). This can later be refactored into it's own `scan_vulnerability_comments` table layer if requirements change.