### PR TITLE
Feature/kt 347 vulnerability detail endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,7 @@ func main() {
 	hostService := services.NewHostService(coreStore)
 	tenantService := services.NewTenantService(coreStore)
 	scanService := services.NewScanService(coreStore)
+	vulnService := services.NewVulnerabilityService(coreStore)
 
 	// Handlers
 	healthHandler := handlers.NewHealthcheckHandlers(healthService)
@@ -58,6 +59,7 @@ func main() {
 	hostHandlers := handlers.NewHostHandlers(hostService)
 	tenantHandlers := handlers.NewTenantHandlers(tenantService)
 	scanHandlers := handlers.NewScanHandlers(scanService, hostService, eventBus)
+	vulnHandlers := handlers.NewVulnerabilityHandlers(vulnService)
 
 	// Event Subscriptions
 	if err := events.SetupEventBus(eventBus, scanService); err != nil {
@@ -72,7 +74,15 @@ func main() {
 	defer storageListener.Close()
 
 	// Server
-	s := api.NewAPIServer(":8000", healthHandler, hostHandlers, tenantHandlers, authHandlers, scanHandlers)
+	s := api.NewAPIServer(
+		":8000",
+		healthHandler,
+		hostHandlers,
+		tenantHandlers,
+		authHandlers,
+		scanHandlers,
+		vulnHandlers,
+	)
 
 	if err := s.Init(); err != nil {
 		slog.Error("Failed to initialize APIServer", slog.Any("error", err))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,6 +20,7 @@ type APIServer struct {
 	authHandlers   interfaces.IAuthHandlers
 	tenantHandlers interfaces.ITenantHandlers
 	scanHandlers   interfaces.IScanHandlers
+	vulnHandlers   interfaces.IVulnerabilityHandlers
 }
 
 type APIError struct {
@@ -35,6 +36,7 @@ func NewAPIServer(
 	teHandlers interfaces.ITenantHandlers,
 	aHandlers interfaces.IAuthHandlers,
 	sHandlers interfaces.IScanHandlers,
+	vHandlers interfaces.IVulnerabilityHandlers,
 ) *APIServer {
 	return &APIServer{
 		listenAddr: listenAddr,
@@ -44,6 +46,7 @@ func NewAPIServer(
 		authHandlers:   aHandlers,
 		tenantHandlers: teHandlers,
 		scanHandlers:   sHandlers,
+		vulnHandlers:   vHandlers,
 	}
 }
 
@@ -82,6 +85,8 @@ func (s *APIServer) Init() error {
 	router.HandleFunc("GET /api/scorecard-trends", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetScoreCardTrends), "getScoreCardTrends"))
 
 	router.HandleFunc("GET /api/reports", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.scanHandlers.GetReports), "getAllTenantReports"))
+
+	router.HandleFunc("GET /api/vulnerabilities/{id}", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.vulnHandlers.GetVulnerability), "getVulnerability"))
 
 	stack := middleware.CreateStack(
 		middleware.Logging,

--- a/pkg/customerrors/vulnerability.go
+++ b/pkg/customerrors/vulnerability.go
@@ -1,0 +1,5 @@
+package customerrors
+
+import "errors"
+
+var ErrVulnNotFound = errors.New("vulnerability not found")

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -65,6 +65,7 @@ func GetValidRoles(funcName string) ([]Role, error) {
 		"getAllTenantReports":             {RoleOperator, RoleAnalyst},
 		"getScoreCardTrends":              {RoleOperator, RoleAnalyst},
 		"getScanVulnerabilities":          {RoleOperator, RoleAnalyst},
+		"getVulnerability":                {RoleOperator, RoleAnalyst},
 	}
 
 	v, ok := funcRoles[funcName]

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -43,3 +43,78 @@ type Vulnerability struct {
 
 	AnalystComment *string
 }
+
+// ScanVulnerabilityDetail is the data structure with the details for a particular
+// scan's vulenrability.
+type ScanVulnerabilityDetail struct {
+	ID       int       `json:"id"`
+	ScanDate time.Time `json:"scan_date"`
+
+	Host HostItem  `json:"host"`
+	Port *PortItem `json:"port,omitempty"`
+	OS   *OSItem   `json:"operating_system,omitempty"`
+
+	Name           string   `json:"name"`
+	Severity       string   `json:"severity"`
+	MaxCVSS        float64  `json:"max_cvss"`
+	RiskScore      float64  `json:"risk_score"`
+	ImpactScore    float64  `json:"impact_score"`
+	Likelihood     string   `json:"likelihood"`
+	Access         string   `json:"access"`
+	Complexity     string   `json:"complexity"`
+	Privileges     string   `json:"privileges"`
+	Exploitability string   `json:"exploitability"`
+	Comment        string   `json:"comment"`
+	Recommendation string   `json:"recommendation"`
+	References     []string `json:"references"`
+
+	DateInfo   DateInfo   `json:"date"`
+	PluginInfo PluginInfo `json:"plugin"`
+	VPRKeyD    VPRKeyInfo `json:"vpr_key_d"`
+	RiskInfo   RiskInfo   `json:"risk"`
+}
+
+type HostItem struct {
+	Alias     string `json:"alias"`
+	IPAddress string `json:"ip_address"`
+}
+
+type PortItem struct {
+	ID       uint16 `json:"id"`
+	Protocol string `json:"protocol"`
+}
+
+type OSItem struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type DateInfo struct {
+	Published   time.Time `json:"published"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// PluginInfo refers to info about the service/operating system
+// associated with the vulnerability
+type PluginInfo struct {
+	CPE      string `json:"cpe"` // CPE
+	Severity string `json:"severity"`
+	Version  string `json:"version"`
+	Type     string `json:"type"`   // AccessType
+	Family   string `json:"family"` // OS = family, Sevice = Product
+}
+
+type VPRKeyInfo struct {
+	ThreatIntensity string `json:"threat_intensity"`
+	ExploitMaturity string `json:"exploit_code_maturity"`
+	VulnAge         int    `json:"age_of_vuln"`
+	ProductCoverage string `json:"product_coverage"` // Availability impact
+}
+
+type RiskInfo struct {
+	RiskScore          float64 `json:"risk_score"`
+	AvailabilityImpact string  `json:"availability_impact"`
+	IntegrityImpact    string  `json:"integrity_impact"`
+	CVSSV3Base         float64 `json:"cvss_v3_base"`
+	CVSSV30Vector      string  `json:"cvss_v3_vector"`
+}

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -108,3 +108,77 @@ type ScanVulnerabilityItem struct {
 	Comment        string   `json:"comment"`
 	References     []string `json:"references"`
 }
+
+// ScanVulnerabilityDetailResponse is the DTO with the details for a particular
+// scan's vulenrability.
+type ScanVulnerabilityDetailResponse struct {
+	ID       int       `json:"id"`
+	ScanDate time.Time `json:"scan_date"`
+
+	Host HostItem  `json:"host"`
+	Port *PortItem `json:"port,omitempty"`
+	OS   *OSItem   `json:"operating_system,omitempty"`
+
+	Name           string   `json:"name"`
+	Severity       string   `json:"severity"`
+	MaxCVSS        float64  `json:"max_cvss"`
+	RiskScore      float64  `json:"risk_score"`
+	ImpactScore    float64  `json:"impact_score"`
+	Likelihood     string   `json:"likelihood"`
+	Access         string   `json:"access"`
+	Complexity     string   `json:"complexity"`
+	Privileges     string   `json:"privileges"`
+	Exploitability string   `json:"exploitability"`
+	Comment        string   `json:"comment"`
+	References     []string `json:"references"`
+
+	DateInfo   DateInfo   `json:"date"`
+	PluginInfo PluginInfo `json:"plugin"`
+	VPRKeyD    VPRKeyInfo `json:"vpr_key_d"`
+	RiskInfo   RiskInfo   `json:"risk"`
+}
+
+type HostItem struct {
+	Alias     string `json:"alias"`
+	IPAddress string `json:"ip_address"`
+}
+
+type PortItem struct {
+	ID       uint16 `json:"id"`
+	Protocol string `json:"protocol"`
+}
+
+type OSItem struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type DateInfo struct {
+	Published   time.Time `json:"published"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// PluginInfo refers to info about the service/operating system
+// associated with the vulnerability
+type PluginInfo struct {
+	CPE      string `json:"cpe"` // CPE
+	Severity string `json:"severity"`
+	Version  string `json:"version"`
+	Type     string `json:"type"`   // AccessType
+	Family   string `json:"family"` // OS = family, Sevice = Product
+}
+
+type VPRKeyInfo struct {
+	ThreatIntensity string `json:"threat_intensity"`
+	ExploitMaturity string `json:"exploit_code_maturity"`
+	VulnAge         int    `json:"age_of_vuln"`
+	ProductCoverage string `json:"product_coverage"` // Availability impact
+}
+
+type RiskInfo struct {
+	RiskScore          float64  `json:"risk_score"`
+	AvailabilityImpact string   `json:"availability_impact"`
+	IntegrityImpact    string   `json:"integrity_impact"`
+	CVSSV3Base         *float64 `json:"cvss_v3_base"`  // Can be nullable
+	CVSSV30Vector      *string  `json:"cvss_v3_vecto"` // Can be nullable
+}

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -180,8 +180,8 @@ type RiskInfo struct {
 	RiskScore          float64  `json:"risk_score"`
 	AvailabilityImpact string   `json:"availability_impact"`
 	IntegrityImpact    string   `json:"integrity_impact"`
-	CVSSV3Base         *float64 `json:"cvss_v3_base"`  // Can be nullable
-	CVSSV30Vector      *string  `json:"cvss_v3_vecto"` // Can be nullable
+	CVSSV3Base         *float64 `json:"cvss_v3_base"`   // Can be nullable
+	CVSSV30Vector      *string  `json:"cvss_v3_vector"` // Can be nullable
 }
 
 func adaptDomainPortItem(domainPortItem *domain.PortItem) *PortItem {

--- a/pkg/handlers/responses.go
+++ b/pkg/handlers/responses.go
@@ -130,6 +130,7 @@ type ScanVulnerabilityDetailResponse struct {
 	Privileges     string   `json:"privileges"`
 	Exploitability string   `json:"exploitability"`
 	Comment        string   `json:"comment"`
+	Recommendation string   `json:"recommendation"`
 	References     []string `json:"references"`
 
 	DateInfo   DateInfo   `json:"date"`
@@ -181,4 +182,62 @@ type RiskInfo struct {
 	IntegrityImpact    string   `json:"integrity_impact"`
 	CVSSV3Base         *float64 `json:"cvss_v3_base"`  // Can be nullable
 	CVSSV30Vector      *string  `json:"cvss_v3_vecto"` // Can be nullable
+}
+
+func adaptDomainPortItem(domainPortItem *domain.PortItem) *PortItem {
+	if domainPortItem == nil {
+		return nil
+	}
+
+	return &PortItem{
+		ID:       domainPortItem.ID,
+		Protocol: domainPortItem.Protocol,
+	}
+}
+
+func adaptDomainOSItem(domainOSItem *domain.OSItem) *OSItem {
+	if domainOSItem == nil {
+		return nil
+	}
+
+	return &OSItem{
+		Name: domainOSItem.Name,
+		Type: domainOSItem.Type,
+	}
+}
+
+func adaptDomainDateInfo(domainDateInfo domain.DateInfo) DateInfo {
+	return DateInfo{
+		Published:   domainDateInfo.Published,
+		LastUpdated: domainDateInfo.LastUpdated,
+	}
+}
+
+func adaptDomainPluginInfo(domainPluginInfo domain.PluginInfo) PluginInfo {
+	return PluginInfo{
+		CPE:      domainPluginInfo.CPE,
+		Severity: domainPluginInfo.Severity,
+		Version:  domainPluginInfo.Version,
+		Type:     domainPluginInfo.Type,
+		Family:   domainPluginInfo.Family,
+	}
+}
+
+func adaptDomainVPRKeyInfo(domainVPRKeyInfo domain.VPRKeyInfo) VPRKeyInfo {
+	return VPRKeyInfo{
+		ThreatIntensity: domainVPRKeyInfo.ThreatIntensity,
+		ExploitMaturity: domainVPRKeyInfo.ExploitMaturity,
+		VulnAge:         domainVPRKeyInfo.VulnAge,
+		ProductCoverage: domainVPRKeyInfo.ProductCoverage,
+	}
+}
+
+func adaptDomainRiskInfo(domainRiskInfo domain.RiskInfo) RiskInfo {
+	return RiskInfo{
+		RiskScore:          domainRiskInfo.RiskScore,
+		AvailabilityImpact: domainRiskInfo.AvailabilityImpact,
+		IntegrityImpact:    domainRiskInfo.IntegrityImpact,
+		CVSSV3Base:         &domainRiskInfo.CVSSV3Base,
+		CVSSV30Vector:      &domainRiskInfo.CVSSV30Vector,
+	}
 }

--- a/pkg/handlers/vulnerability.go
+++ b/pkg/handlers/vulnerability.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/kptm-tools/core-service/pkg/api"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+)
+
+type VulnerabilityHandlers struct {
+	vulnerabilityService interfaces.IVulnerabilityService
+}
+
+var _ interfaces.IVulnerabilityHandlers = (*VulnerabilityHandlers)(nil)
+
+func NewVulnerabilityHandlers(vulnService interfaces.IVulnerabilityService) *VulnerabilityHandlers {
+	return &VulnerabilityHandlers{
+		vulnerabilityService: vulnService,
+	}
+}
+
+func (h *VulnerabilityHandlers) GetVulnerability(w http.ResponseWriter, r *http.Request) error {
+	vulnID, err := GetID(r)
+	if err != nil {
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{
+			Error: fmt.Sprintf("ID is invalid: %v", err),
+		})
+	}
+
+	vulnDetail, err := h.vulnerabilityService.GetScanVulnerabilityDetail(vulnID)
+	if err != nil {
+		slog.Error("Failed to GetScanVulnerabilityDetail",
+			slog.Int("vuln_id", vulnID),
+			slog.Any("error", err),
+		)
+		if errors.Is(err, customerrors.ErrVulnNotFound) {
+			return api.WriteJSON(w, http.StatusNotFound, api.APIError{
+				Error: fmt.Sprintf("Could not find vulnerability with ID %d", vulnID),
+			})
+		}
+		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{
+			Error: http.StatusText(http.StatusInternalServerError),
+		})
+	}
+
+	vulnDetailResponse := ScanVulnerabilityDetailResponse{
+		ID:       vulnDetail.ID,
+		ScanDate: vulnDetail.ScanDate,
+
+		Host: HostItem{
+			Alias:     vulnDetail.Host.Alias,
+			IPAddress: vulnDetail.Host.IPAddress,
+		},
+		Port: adaptDomainPortItem(vulnDetail.Port),
+		OS:   adaptDomainOSItem(vulnDetail.OS),
+
+		Name:           vulnDetail.Name,
+		Severity:       vulnDetail.Severity,
+		MaxCVSS:        vulnDetail.MaxCVSS,
+		RiskScore:      vulnDetail.RiskScore,
+		ImpactScore:    vulnDetail.ImpactScore,
+		Likelihood:     vulnDetail.Likelihood,
+		Access:         vulnDetail.Access,
+		Complexity:     vulnDetail.Complexity,
+		Privileges:     vulnDetail.Privileges,
+		Exploitability: vulnDetail.Exploitability,
+		Comment:        vulnDetail.Comment,
+		Recommendation: vulnDetail.Recommendation,
+		References:     vulnDetail.References,
+
+		DateInfo:   adaptDomainDateInfo(vulnDetail.DateInfo),
+		PluginInfo: adaptDomainPluginInfo(vulnDetail.PluginInfo),
+		VPRKeyD:    adaptDomainVPRKeyInfo(vulnDetail.VPRKeyD),
+		RiskInfo:   adaptDomainRiskInfo(vulnDetail.RiskInfo),
+	}
+
+	return api.WriteJSON(w, http.StatusOK, vulnDetailResponse)
+}

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -39,4 +39,7 @@ type IStorage interface {
 	GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetScanVulnerabilities(uuid.UUID) ([]*domain.Vulnerability, error)
 	GetSeverityCounts(uuid.UUID) (*tools.SeverityCounts, error)
+	GetVulnerabilityByID(int) (*domain.Vulnerability, error)
+	GetOSByID(int) (*tools.OSData, error)
+	GetServiceByID(int) (*tools.PortData, error)
 }

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -1,0 +1,15 @@
+package interfaces
+
+import (
+	"net/http"
+
+	"github.com/kptm-tools/core-service/pkg/domain"
+)
+
+type IVulnerabilityService interface {
+	GetScanVulnerabilityDetail(vulnID int) (*domain.ScanVulnerabilityDetail, error)
+}
+
+type IVulnerabilityHandlers interface {
+	GetVulnerability(w http.ResponseWriter, r *http.Request) error
+}

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -1,0 +1,269 @@
+package mocks
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/domain"
+)
+
+type MockStorage struct {
+	MockCreateHost                    func(*domain.Host) (*domain.Host, error)
+	MockGetHostsByTenantID            func(string) ([]*domain.Host, error)
+	MockGetHostByID                   func(int) (*domain.Host, error)
+	MockDeleteHostByID                func(int) (bool, error)
+	MockPatchHostByID                 func(*domain.Host) (*domain.Host, error)
+	MockCreateTenant                  func(*domain.Tenant) (*domain.Tenant, error)
+	MockGetTenants                    func() ([]*domain.Tenant, error)
+	MockPing                          func() error
+	MockCreateScan                    func(*domain.Scan) (*domain.Scan, error)
+	MockExistAlias                    func(string) (bool, error)
+	MockGetScans                      func(tenantID string) ([]*domain.ScanSummary, error)
+	MockGetScanByID                   func(UUID uuid.UUID) (*domain.Scan, error)
+	MockInsertScanResult              func(*sql.Tx, *domain.ScanResult) error
+	MockInsertVulnerabilityResult     func(*domain.ScanResult) error
+	MockUpdateScanStatus              func(scanID uuid.UUID, status string) error
+	MockUpdateScanStatusAndEndedAt    func(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error
+	MockGetScanInsights               func(scanID uuid.UUID) (*domain.ScanInsights, error)
+	MockGetProtectionScore            func(scanID uuid.UUID) (float64, error)
+	MockUpdateProtectionScore         func(scanID uuid.UUID, score float64) error
+	MockGetWhoisResult                func(scanID uuid.UUID) (*tools.WhoIsResult, error)
+	MockGetDNSLookupResult            func(scanID uuid.UUID) (*tools.DNSLookupResult, error)
+	MockGetHarvesterResult            func(scanID uuid.UUID) (*tools.HarvesterResult, error)
+	MockGetNmapResult                 func(scanID uuid.UUID) (*tools.NmapResult, error)
+	MockGetScanVulnerabilitiesSummary func(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	MockGetReportsByTenantID          func(tenantID string) ([]*domain.ReportItem, error)
+	MockGetLatestScanByHostID         func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
+	MockGetOldestScanByHostID         func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
+	MockGetScanVulnerabilities        func(uuid.UUID) ([]*domain.Vulnerability, error)
+	MockGetSeverityCounts             func(uuid.UUID) (*tools.SeverityCounts, error)
+	MockGetOSByID                     func(int) (*tools.OSData, error)
+	MockGetServiceByID                func(int) (*tools.PortData, error)
+	MockGetVulnerabilityByID          func(int) (*domain.Vulnerability, error)
+}
+
+func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
+	if m.MockCreateHost != nil {
+		return m.MockCreateHost(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHostsByTenantID(arg0 string) ([]*domain.Host, error) {
+	if m.MockGetHostsByTenantID != nil {
+		return m.MockGetHostsByTenantID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHostByID(arg0 int) (*domain.Host, error) {
+	if m.MockGetHostByID != nil {
+		return m.MockGetHostByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) DeleteHostByID(arg0 int) (bool, error) {
+	if m.MockDeleteHostByID != nil {
+		return m.MockDeleteHostByID(arg0)
+	}
+	return false, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) PatchHostByID(arg0 *domain.Host) (*domain.Host, error) {
+	if m.MockPatchHostByID != nil {
+		return m.MockPatchHostByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) CreateTenant(arg0 *domain.Tenant) (*domain.Tenant, error) {
+	if m.MockCreateTenant != nil {
+		return m.MockCreateTenant(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetTenants() ([]*domain.Tenant, error) {
+	if m.MockGetTenants != nil {
+		return m.MockGetTenants()
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) Ping() error {
+	if m.MockPing != nil {
+		return m.MockPing()
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) CreateScan(arg0 *domain.Scan) (*domain.Scan, error) {
+	if m.MockCreateScan != nil {
+		return m.MockCreateScan(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) ExistAlias(arg0 string) (bool, error) {
+	if m.MockExistAlias != nil {
+		return m.MockExistAlias(arg0)
+	}
+	return false, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScans(tenantID string) ([]*domain.ScanSummary, error) {
+	if m.MockGetScans != nil {
+		return m.MockGetScans(tenantID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanByID(arg0 uuid.UUID) (*domain.Scan, error) {
+	if m.MockGetScanByID != nil {
+		return m.MockGetScanByID(arg0)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) InsertScanResult(arg0 *sql.Tx, arg1 *domain.ScanResult) error {
+	if m.MockInsertScanResult != nil {
+		return m.MockInsertScanResult(arg0, arg1)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) InsertVulnerabilityResult(arg0 *domain.ScanResult) error {
+	if m.MockInsertVulnerabilityResult != nil {
+		return m.MockInsertVulnerabilityResult(arg0)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateScanStatus(scanID uuid.UUID, status string) error {
+	if m.MockUpdateScanStatus != nil {
+		return m.MockUpdateScanStatus(scanID, status)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateScanStatusAndEndedAt(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error {
+	if m.MockUpdateScanStatusAndEndedAt != nil {
+		return m.MockUpdateScanStatusAndEndedAt(tx, scanID, status, endedAt)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanInsights(scanID uuid.UUID) (*domain.ScanInsights, error) {
+	if m.MockGetScanInsights != nil {
+		return m.MockGetScanInsights(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetProtectionScore(scanID uuid.UUID) (float64, error) {
+	if m.MockGetProtectionScore != nil {
+		return m.MockGetProtectionScore(scanID)
+	}
+	return 0, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) UpdateProtectionScore(scanID uuid.UUID, score float64) error {
+	if m.MockUpdateProtectionScore != nil {
+		return m.MockUpdateProtectionScore(scanID, score)
+	}
+	return nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetWhoisResult(scanID uuid.UUID) (*tools.WhoIsResult, error) {
+	if m.MockGetWhoisResult != nil {
+		return m.MockGetWhoisResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error) {
+	if m.MockGetDNSLookupResult != nil {
+		return m.MockGetDNSLookupResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error) {
+	if m.MockGetHarvesterResult != nil {
+		return m.MockGetHarvesterResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error) {
+	if m.MockGetNmapResult != nil {
+		return m.MockGetNmapResult(scanID)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
+	if m.MockGetScanVulnerabilitiesSummary != nil {
+		return m.MockGetScanVulnerabilitiesSummary(scanID, timePeriodFilter, severityFilters)
+	}
+	return nil, nil // Default behavior if mock function not set
+}
+
+func (m *MockStorage) GetReportsByTenantID(tenantID string) ([]*domain.ReportItem, error) {
+	if m.MockGetReportsByTenantID != nil {
+		return m.MockGetReportsByTenantID(tenantID)
+	}
+	return nil, nil // Default behaviour if mock function is not set
+}
+
+func (m *MockStorage) GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+	if m.MockGetLatestScanByHostID != nil {
+		return m.MockGetLatestScanByHostID(hostID, fromDate, toDate)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+	if m.MockGetOldestScanByHostID != nil {
+		return m.MockGetOldestScanByHostID(hostID, fromDate, toDate)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulnerability, error) {
+	if m.MockGetScanVulnerabilities != nil {
+		return m.MockGetScanVulnerabilities(scanID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetSeverityCounts(scanID uuid.UUID) (*tools.SeverityCounts, error) {
+	if m.MockGetSeverityCounts != nil {
+		return m.MockGetSeverityCounts(scanID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetOSByID(operatingSystemID int) (*tools.OSData, error) {
+	if m.MockGetOSByID != nil {
+		return m.MockGetOSByID(operatingSystemID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetServiceByID(serviceID int) (*tools.PortData, error) {
+	if m.MockGetServiceByID != nil {
+		return m.MockGetServiceByID(serviceID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetVulnerabilityByID(vulnID int) (*domain.Vulnerability, error) {
+	if m.MockGetVulnerabilityByID != nil {
+		return m.MockGetVulnerabilityByID(vulnID)
+	}
+	return nil, nil
+}

--- a/pkg/services/scan_service_test.go
+++ b/pkg/services/scan_service_test.go
@@ -1,278 +1,18 @@
 package services
 
 import (
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
-type MockStorage struct {
-	MockCreateHost                    func(*domain.Host) (*domain.Host, error)
-	MockGetHostsByTenantID            func(string) ([]*domain.Host, error)
-	MockGetHostByID                   func(int) (*domain.Host, error)
-	MockDeleteHostByID                func(int) (bool, error)
-	MockPatchHostByID                 func(*domain.Host) (*domain.Host, error)
-	MockCreateTenant                  func(*domain.Tenant) (*domain.Tenant, error)
-	MockGetTenants                    func() ([]*domain.Tenant, error)
-	MockPing                          func() error
-	MockCreateScan                    func(*domain.Scan) (*domain.Scan, error)
-	MockExistAlias                    func(string) (bool, error)
-	MockGetScans                      func(tenantID string) ([]*domain.ScanSummary, error)
-	MockGetScanByID                   func(UUID uuid.UUID) (*domain.Scan, error)
-	MockInsertScanResult              func(*sql.Tx, *domain.ScanResult) error
-	MockInsertVulnerabilityResult     func(*domain.ScanResult) error
-	MockUpdateScanStatus              func(scanID uuid.UUID, status string) error
-	MockUpdateScanStatusAndEndedAt    func(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error
-	MockGetScanInsights               func(scanID uuid.UUID) (*domain.ScanInsights, error)
-	MockGetProtectionScore            func(scanID uuid.UUID) (float64, error)
-	MockUpdateProtectionScore         func(scanID uuid.UUID, score float64) error
-	MockGetWhoisResult                func(scanID uuid.UUID) (*tools.WhoIsResult, error)
-	MockGetDNSLookupResult            func(scanID uuid.UUID) (*tools.DNSLookupResult, error)
-	MockGetHarvesterResult            func(scanID uuid.UUID) (*tools.HarvesterResult, error)
-	MockGetNmapResult                 func(scanID uuid.UUID) (*tools.NmapResult, error)
-	MockGetScanVulnerabilitiesSummary func(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
-	MockGetReportsByTenantID          func(tenantID string) ([]*domain.ReportItem, error)
-	MockGetLatestScanByHostID         func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
-	MockGetOldestScanByHostID         func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
-	MockGetScanVulnerabilities        func(uuid.UUID) ([]*domain.Vulnerability, error)
-	MockGetSeverityCounts             func(uuid.UUID) (*tools.SeverityCounts, error)
-	MockGetOSByID                     func(int) (*tools.OSData, error)
-	MockGetServiceByID                func(int) (*tools.PortData, error)
-	MockGetVulnerabilityByID          func(int) (*domain.Vulnerability, error)
-}
-
-func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
-	if m.MockCreateHost != nil {
-		return m.MockCreateHost(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetHostsByTenantID(arg0 string) ([]*domain.Host, error) {
-	if m.MockGetHostsByTenantID != nil {
-		return m.MockGetHostsByTenantID(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetHostByID(arg0 int) (*domain.Host, error) {
-	if m.MockGetHostByID != nil {
-		return m.MockGetHostByID(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) DeleteHostByID(arg0 int) (bool, error) {
-	if m.MockDeleteHostByID != nil {
-		return m.MockDeleteHostByID(arg0)
-	}
-	return false, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) PatchHostByID(arg0 *domain.Host) (*domain.Host, error) {
-	if m.MockPatchHostByID != nil {
-		return m.MockPatchHostByID(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) CreateTenant(arg0 *domain.Tenant) (*domain.Tenant, error) {
-	if m.MockCreateTenant != nil {
-		return m.MockCreateTenant(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetTenants() ([]*domain.Tenant, error) {
-	if m.MockGetTenants != nil {
-		return m.MockGetTenants()
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) Ping() error {
-	if m.MockPing != nil {
-		return m.MockPing()
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) CreateScan(arg0 *domain.Scan) (*domain.Scan, error) {
-	if m.MockCreateScan != nil {
-		return m.MockCreateScan(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) ExistAlias(arg0 string) (bool, error) {
-	if m.MockExistAlias != nil {
-		return m.MockExistAlias(arg0)
-	}
-	return false, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetScans(tenantID string) ([]*domain.ScanSummary, error) {
-	if m.MockGetScans != nil {
-		return m.MockGetScans(tenantID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetScanByID(arg0 uuid.UUID) (*domain.Scan, error) {
-	if m.MockGetScanByID != nil {
-		return m.MockGetScanByID(arg0)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) InsertScanResult(arg0 *sql.Tx, arg1 *domain.ScanResult) error {
-	if m.MockInsertScanResult != nil {
-		return m.MockInsertScanResult(arg0, arg1)
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) InsertVulnerabilityResult(arg0 *domain.ScanResult) error {
-	if m.MockInsertVulnerabilityResult != nil {
-		return m.MockInsertVulnerabilityResult(arg0)
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) UpdateScanStatus(scanID uuid.UUID, status string) error {
-	if m.MockUpdateScanStatus != nil {
-		return m.MockUpdateScanStatus(scanID, status)
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) UpdateScanStatusAndEndedAt(tx *sql.Tx, scanID uuid.UUID, status string, endedAt time.Time) error {
-	if m.MockUpdateScanStatusAndEndedAt != nil {
-		return m.MockUpdateScanStatusAndEndedAt(tx, scanID, status, endedAt)
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetScanInsights(scanID uuid.UUID) (*domain.ScanInsights, error) {
-	if m.MockGetScanInsights != nil {
-		return m.MockGetScanInsights(scanID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetProtectionScore(scanID uuid.UUID) (float64, error) {
-	if m.MockGetProtectionScore != nil {
-		return m.MockGetProtectionScore(scanID)
-	}
-	return 0, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) UpdateProtectionScore(scanID uuid.UUID, score float64) error {
-	if m.MockUpdateProtectionScore != nil {
-		return m.MockUpdateProtectionScore(scanID, score)
-	}
-	return nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetWhoisResult(scanID uuid.UUID) (*tools.WhoIsResult, error) {
-	if m.MockGetWhoisResult != nil {
-		return m.MockGetWhoisResult(scanID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error) {
-	if m.MockGetDNSLookupResult != nil {
-		return m.MockGetDNSLookupResult(scanID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error) {
-	if m.MockGetHarvesterResult != nil {
-		return m.MockGetHarvesterResult(scanID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error) {
-	if m.MockGetNmapResult != nil {
-		return m.MockGetNmapResult(scanID)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
-	if m.MockGetScanVulnerabilitiesSummary != nil {
-		return m.MockGetScanVulnerabilitiesSummary(scanID, timePeriodFilter, severityFilters)
-	}
-	return nil, nil // Default behavior if mock function not set
-}
-
-func (m *MockStorage) GetReportsByTenantID(tenantID string) ([]*domain.ReportItem, error) {
-	if m.MockGetReportsByTenantID != nil {
-		return m.MockGetReportsByTenantID(tenantID)
-	}
-	return nil, nil // Default behaviour if mock function is not set
-}
-
-func (m *MockStorage) GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
-	if m.MockGetLatestScanByHostID != nil {
-		return m.MockGetLatestScanByHostID(hostID, fromDate, toDate)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
-	if m.MockGetOldestScanByHostID != nil {
-		return m.MockGetOldestScanByHostID(hostID, fromDate, toDate)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulnerability, error) {
-	if m.MockGetScanVulnerabilities != nil {
-		return m.MockGetScanVulnerabilities(scanID)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetSeverityCounts(scanID uuid.UUID) (*tools.SeverityCounts, error) {
-	if m.MockGetSeverityCounts != nil {
-		return m.MockGetSeverityCounts(scanID)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetOSByID(operatingSystemID int) (*tools.OSData, error) {
-	if m.MockGetOSByID != nil {
-		return m.MockGetOSByID(operatingSystemID)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetServiceByID(serviceID int) (*tools.PortData, error) {
-	if m.MockGetServiceByID != nil {
-		return m.MockGetServiceByID(serviceID)
-	}
-	return nil, nil
-}
-
-func (m *MockStorage) GetVulnerabilityByID(vulnID int) (*domain.Vulnerability, error) {
-	if m.MockGetVulnerabilityByID != nil {
-		return m.MockGetVulnerabilityByID(vulnID)
-	}
-	return nil, nil
-}
-
 func Test_GetReportsByTenantID_NoReports(t *testing.T) {
-	mockStore := &MockStorage{
+	mockStore := &mocks.MockStorage{
 		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
 			return nil, nil
 		},
@@ -288,7 +28,7 @@ func Test_GetReportsByTenantID_NoReports(t *testing.T) {
 }
 
 func Test_GetReportsByTenantID_StorageError(t *testing.T) {
-	mockStore := &MockStorage{
+	mockStore := &mocks.MockStorage{
 		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
 			return nil, errors.New("database connection failed")
 		},
@@ -323,7 +63,7 @@ func Test_GetReportsByTenantID_Success(t *testing.T) {
 			CommentStatus:   domain.CommentStatusNewComment,
 		},
 	}
-	mockStore := &MockStorage{
+	mockStore := &mocks.MockStorage{
 		MockGetReportsByTenantID: func(tenantID string) ([]*domain.ReportItem, error) {
 			return sampleReports, nil
 		},

--- a/pkg/services/scan_service_test.go
+++ b/pkg/services/scan_service_test.go
@@ -42,6 +42,9 @@ type MockStorage struct {
 	MockGetOldestScanByHostID         func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetScanVulnerabilities        func(uuid.UUID) ([]*domain.Vulnerability, error)
 	MockGetSeverityCounts             func(uuid.UUID) (*tools.SeverityCounts, error)
+	MockGetOSByID                     func(int) (*tools.OSData, error)
+	MockGetServiceByID                func(int) (*tools.PortData, error)
+	MockGetVulnerabilityByID          func(int) (*domain.Vulnerability, error)
 }
 
 func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
@@ -243,6 +246,27 @@ func (m *MockStorage) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulner
 func (m *MockStorage) GetSeverityCounts(scanID uuid.UUID) (*tools.SeverityCounts, error) {
 	if m.MockGetSeverityCounts != nil {
 		return m.MockGetSeverityCounts(scanID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetOSByID(operatingSystemID int) (*tools.OSData, error) {
+	if m.MockGetOSByID != nil {
+		return m.MockGetOSByID(operatingSystemID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetServiceByID(serviceID int) (*tools.PortData, error) {
+	if m.MockGetServiceByID != nil {
+		return m.MockGetServiceByID(serviceID)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetVulnerabilityByID(vulnID int) (*domain.Vulnerability, error) {
+	if m.MockGetVulnerabilityByID != nil {
+		return m.MockGetVulnerabilityByID(vulnID)
 	}
 	return nil, nil
 }

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -56,7 +56,7 @@ func (s *VulnerabilityService) GetScanVulnerabilityDetail(vulnID int) (*domain.S
 		// 2.1 Operating system vulnerabilty
 		operatingSystem, err := s.storage.GetOSByID(*vuln.OperatingSystemID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch OS by ID %s: %w", *vuln.OperatingSystemID, err)
+			return nil, fmt.Errorf("failed to fetch OS by ID %d: %w", *vuln.OperatingSystemID, err)
 		}
 		OSItemPtr = &domain.OSItem{
 			Name: operatingSystem.Name,
@@ -149,6 +149,6 @@ func (s *VulnerabilityService) getPluginInfoForService(portData *tools.PortData,
 }
 
 func calculateVulnerabiltyAgeDays(timePublished time.Time) int {
-	durationInDaysFloat := time.Now().Sub(timePublished).Hours() / 24
+	durationInDaysFloat := time.Since(timePublished).Hours() / 24
 	return int(durationInDaysFloat)
 }

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+)
+
+type VulnerabilityService struct {
+	storage interfaces.IStorage
+}
+
+var _ interfaces.IVulnerabilityService = (*VulnerabilityService)(nil)
+
+func NewVulnerabilityService(storage interfaces.IStorage) *VulnerabilityService {
+	return &VulnerabilityService{
+		storage: storage,
+	}
+}
+
+func (s *VulnerabilityService) GetScanVulnerabilityDetail(vulnID int) (*domain.ScanVulnerabilityDetail, error) {
+	vuln, err := s.storage.GetVulnerabilityByID(vulnID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch vulnerability by ID %d: %w", vulnID, err)
+	}
+
+	scan, err := s.storage.GetScanByID(vuln.ScanID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch scan by ID %s: %w", vuln.ScanID.String(), err)
+	}
+
+	host, err := s.storage.GetHostByID(vuln.HostID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch host by ID %d: %w", vuln.HostID, err)
+	}
+
+	// Build ScanVulnerabilityDetail with the data
+	var vulnDetail domain.ScanVulnerabilityDetail
+
+	// Check for possible nil values
+	// 1. AnalystComment
+	analystComment := ""
+	if vuln.AnalystComment != nil {
+		analystComment = *vuln.AnalystComment
+	}
+
+	// 2. Fetch OS and Port Item Data
+	var pluginInfo domain.PluginInfo
+	var portItemPtr *domain.PortItem
+	var OSItemPtr *domain.OSItem
+
+	if vuln.OperatingSystemID != nil {
+		// 2.1 Operating system vulnerabilty
+		operatingSystem, err := s.storage.GetOSByID(*vuln.OperatingSystemID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch OS by ID %s: %w", *vuln.OperatingSystemID, err)
+		}
+		OSItemPtr = &domain.OSItem{
+			Name: operatingSystem.Name,
+			Type: operatingSystem.Type,
+		}
+		pluginInfo = s.getPluginInfoForOS(operatingSystem, vuln)
+	} else if vuln.ServiceID != nil {
+		// 2.2 Service vulnerability
+		portData, err := s.storage.GetServiceByID(*vuln.ServiceID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch service by ID %d: %w", *vuln.ServiceID, err)
+		}
+		portItemPtr = &domain.PortItem{
+			ID:       portData.ID,
+			Protocol: portData.Protocol,
+		}
+		pluginInfo = s.getPluginInfoForService(portData, vuln)
+	}
+
+	// 2.3 Assign to vulner detail
+	vulnDetail = domain.ScanVulnerabilityDetail{
+		ID:       vuln.ID,
+		ScanDate: scan.StartedAt,
+
+		Host: domain.HostItem{
+			Alias:     host.Name,
+			IPAddress: host.IP,
+		},
+		Port: portItemPtr,
+		OS:   OSItemPtr,
+
+		Name:           vuln.VulnerabilityID,
+		Severity:       vuln.BaseSeverity.String(),
+		MaxCVSS:        vuln.BaseCVSSScore,
+		RiskScore:      vuln.RiskScore,
+		ImpactScore:    vuln.ImpactScore,
+		Likelihood:     vuln.Likelihood.String(),
+		Access:         vuln.AccessType.String(),
+		Complexity:     vuln.Complexity.String(),
+		Privileges:     vuln.PrivilegesRequired.String(),
+		Exploitability: vuln.Exploit.Exploitability.String(),
+		Comment:        analystComment,
+		Recommendation: "", // TODO: Populate this field with vendor recommendation, if any
+		References:     vuln.References,
+
+		DateInfo: domain.DateInfo{
+			Published:   vuln.Published,
+			LastUpdated: vuln.LastUpdated,
+		},
+
+		PluginInfo: pluginInfo,
+
+		VPRKeyD: domain.VPRKeyInfo{
+			ThreatIntensity: vuln.BaseSeverity.String(),
+			ExploitMaturity: vuln.Exploit.Exploitability.String(),
+			VulnAge:         calculateVulnerabiltyAgeDays(vuln.Published),
+			ProductCoverage: vuln.AvailabilityImpact.String(),
+		},
+
+		RiskInfo: domain.RiskInfo{
+			RiskScore:          vuln.RiskScore,
+			AvailabilityImpact: vuln.AvailabilityImpact.String(),
+			IntegrityImpact:    vuln.IntegrityImpact.String(),
+			CVSSV3Base:         vuln.BaseCVSSScore,
+			CVSSV30Vector:      vuln.AccessType.String(),
+		},
+	}
+
+	return &vulnDetail, nil
+}
+
+func (s *VulnerabilityService) getPluginInfoForOS(osData *tools.OSData, vuln *domain.Vulnerability) domain.PluginInfo {
+	return domain.PluginInfo{
+		CPE:      osData.CPE,
+		Severity: vuln.BaseSeverity.String(),
+		Version:  osData.CPE,
+		Type:     osData.Type,
+		Family:   osData.Family,
+	}
+}
+
+func (s *VulnerabilityService) getPluginInfoForService(portData *tools.PortData, vuln *domain.Vulnerability) domain.PluginInfo {
+	return domain.PluginInfo{
+		CPE:      portData.Service.CPE,
+		Severity: vuln.BaseSeverity.String(),
+		Version:  portData.Service.Version,
+		Type:     portData.Service.Name,
+		Family:   portData.Product,
+	}
+}
+
+func calculateVulnerabiltyAgeDays(timePublished time.Time) int {
+	durationInDaysFloat := time.Now().Sub(timePublished).Hours() / 24
+	return int(durationInDaysFloat)
+}

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/mocks"
 	"github.com/stretchr/testify/assert"
@@ -142,4 +144,33 @@ func Test_GetVulnerability_Success(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedDetail, vulnDetail)
+}
+
+func Test_GetVulnerabilty_VulnerabilityNotFound(t *testing.T) {
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			return nil, fmt.Errorf("%w %d", customerrors.ErrVulnNotFound, vulnID)
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return &domain.Scan{}, nil
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) {
+			return &domain.Host{}, nil
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) {
+			return &tools.OSData{}, nil
+		},
+		MockGetServiceByID: func(serviceID int) (*tools.PortData, error) {
+			return &tools.PortData{}, nil
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 999
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.Error(t, err)
+	assert.Nil(t, vulnDetail)
+	assert.ErrorIs(t, err, customerrors.ErrVulnNotFound)
 }

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -174,3 +174,33 @@ func Test_GetVulnerabilty_VulnerabilityNotFound(t *testing.T) {
 	assert.Nil(t, vulnDetail)
 	assert.ErrorIs(t, err, customerrors.ErrVulnNotFound)
 }
+
+func Test_GetVulnerability_ScanNotFound(t *testing.T) {
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			return &domain.Vulnerability{ScanID: uuid.New()}, // Return vuln with a ScanID
+				nil
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return nil, fmt.Errorf("failed to get scan by ID: %w", customerrors.ErrScanNotFound)
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) { // Mock Host to avoid nil pointer dereference in service
+			return &domain.Host{}, nil
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) { // Mock OS to avoid nil pointer dereference in service
+			return &tools.OSData{}, nil
+		},
+		MockGetServiceByID: func(serviceID int) (*tools.PortData, error) { // Mock Service to avoid nil pointer dereference in service
+			return &tools.PortData{}, nil
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 6
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.Error(t, err)
+	assert.Nil(t, vulnDetail)
+	assert.ErrorIs(t, err, customerrors.ErrScanNotFound)
+}

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -204,3 +204,99 @@ func Test_GetVulnerability_ScanNotFound(t *testing.T) {
 	assert.Nil(t, vulnDetail)
 	assert.ErrorIs(t, err, customerrors.ErrScanNotFound)
 }
+
+func Test_GetVulnerability_HostNotFound(t *testing.T) {
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			return &domain.Vulnerability{ScanID: uuid.New()}, // Return vuln with a ScanID
+				nil
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return &domain.Scan{}, nil
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) { // Mock Host to avoid nil pointer dereference in service
+			return nil, fmt.Errorf("failed to get host by ID: %w", customerrors.ErrHostNotFound)
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) { // Mock OS to avoid nil pointer dereference in service
+			return &tools.OSData{}, nil
+		},
+		MockGetServiceByID: func(serviceID int) (*tools.PortData, error) { // Mock Service to avoid nil pointer dereference in service
+			return &tools.PortData{}, nil
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 6
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.Error(t, err)
+	assert.Nil(t, vulnDetail)
+	assert.ErrorIs(t, err, customerrors.ErrHostNotFound)
+}
+
+func Test_GetVulnerability_OSNotFound(t *testing.T) {
+	operatingSystemID := 5
+	osIDPtr := &operatingSystemID
+
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			return &domain.Vulnerability{ScanID: uuid.New(), OperatingSystemID: osIDPtr}, // Return vuln with a ScanID
+				nil
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return &domain.Scan{}, nil
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) { // Mock Host to avoid nil pointer dereference in service
+			return &domain.Host{}, nil
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) { // Mock OS to avoid nil pointer dereference in service
+			return nil, fmt.Errorf("failed to get operating system by ID: %w", customerrors.ErrOSNotFound)
+		},
+		MockGetServiceByID: func(serviceID int) (*tools.PortData, error) { // Mock Service to avoid nil pointer dereference in service
+			return &tools.PortData{}, nil
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 6
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.Error(t, err)
+	assert.Nil(t, vulnDetail)
+	assert.ErrorIs(t, err, customerrors.ErrOSNotFound)
+}
+
+func Test_GetVulnerability_ServiceNotFound(t *testing.T) {
+	serviceID := 5
+	serviceIDPtr := &serviceID
+
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			return &domain.Vulnerability{ScanID: uuid.New(), ServiceID: serviceIDPtr}, // Return vuln with a ScanID
+				nil
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return &domain.Scan{}, nil
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) { // Mock Host to avoid nil pointer dereference in service
+			return &domain.Host{}, nil
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) { // Mock OS to avoid nil pointer dereference in service
+			return &tools.OSData{}, nil
+		},
+		MockGetServiceByID: func(serviceID int) (*tools.PortData, error) { // Mock Service to avoid nil pointer dereference in service
+			return nil, fmt.Errorf("failed to get service by ID: %w", customerrors.ErrServiceNotFound)
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 6
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.Error(t, err)
+	assert.Nil(t, vulnDetail)
+	assert.ErrorIs(t, err, customerrors.ErrServiceNotFound)
+}

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -1,0 +1,145 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/pkg/enums"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetVulnerability_Success(t *testing.T) {
+	scanStartTime := time.Now()
+	mockScanID, err := uuid.NewRandom()
+	mockHostID := 5
+
+	mockStore := &mocks.MockStorage{
+		MockGetVulnerabilityByID: func(vulnID int) (*domain.Vulnerability, error) {
+			operatingSystemID := 5
+			osIDPtr := &operatingSystemID
+			analystComment := "Wow you should really do something about this one"
+
+			if err != nil {
+				t.Fatalf("failed to generate random UUID %+v", err)
+			}
+			return &domain.Vulnerability{
+				ID:                6,
+				VulnerabilityID:   "CVE-2021-25216",
+				ScanID:            mockScanID,
+				HostID:            mockHostID,
+				OperatingSystemID: osIDPtr,
+				ServiceID:         nil,
+
+				Type:          "CVE",
+				BaseCVSSScore: 5.5,
+				References:    []string{"https://vulners.com/cve/CVE-2021-25216"},
+
+				Description:        "This is a very intense vulnerability",
+				AccessType:         enums.AccessTypeNetwork,
+				Complexity:         enums.ComplexityTypeLow,
+				PrivilegesRequired: enums.PrivilegesRequiredHigh,
+				Likelihood:         enums.LikelyhoodTypeHigh,
+				RiskScore:          20.5,
+				ImpactScore:        5,
+
+				Exploit: tools.Exploit{
+					Score:          4.4,
+					Exploitability: enums.ExploitabilityTypeFunctional,
+				},
+
+				IntegrityImpact:    enums.ImpactTypeHigh,
+				AvailabilityImpact: enums.ImpactTypeNone,
+				BaseSeverity:       enums.SeverityTypeCritical,
+
+				Published:   time.Date(2014, time.August, 10, 10, 10, 0, 0, time.Local),
+				LastUpdated: time.Date(2014, time.August, 10, 10, 10, 0, 0, time.Local),
+
+				AnalystComment: &analystComment,
+			}, nil
+		},
+		MockGetScanByID: func(scanID uuid.UUID) (*domain.Scan, error) {
+			return &domain.Scan{
+				ID:        mockScanID,
+				StartedAt: scanStartTime,
+			}, nil
+		},
+		MockGetHostByID: func(hostID int) (*domain.Host, error) {
+			return &domain.Host{
+				ID:   mockHostID,
+				Name: "google.com",
+				IP:   "8.8.8.8",
+			}, nil
+		},
+		MockGetOSByID: func(osID int) (*tools.OSData, error) {
+			return &tools.OSData{
+				Name: "TestOS",
+				Type: "Linux",
+				CPE:  "cpe:/o:test:testos:1.0",
+			}, nil
+		},
+	}
+
+	vulnService := NewVulnerabilityService(mockStore)
+
+	vulnID := 6
+	vulnDetail, err := vulnService.GetScanVulnerabilityDetail(vulnID)
+
+	assert.NoError(t, err)
+
+	expectedDetail := &domain.ScanVulnerabilityDetail{ // Define expectedDetail based on mocks and image
+		ID:       6,
+		ScanDate: scanStartTime,
+		Host: domain.HostItem{
+			Alias:     "google.com", // From MockGetHostByID
+			IPAddress: "8.8.8.8",    // From MockGetHostByID
+		},
+		Port: nil, // No ServiceID in Vulnerability mock
+		OS: &domain.OSItem{
+			Name: "TestOS", // From MockGetOSByID
+			Type: "Linux",  // From MockGetOSByID
+		},
+		Name:           "CVE-2021-25216",                                    // From MockGetVulnerabilityByID
+		Severity:       enums.SeverityTypeCritical.String(),                 // From MockGetVulnerabilityByID
+		MaxCVSS:        5.5,                                                 // From MockGetVulnerabilityByID
+		RiskScore:      20.5,                                                // From MockGetVulnerabilityByID - Updated to match image
+		ImpactScore:    5,                                                   // From MockGetVulnerabilityByID - Updated to match image
+		Likelihood:     enums.LikelyhoodTypeHigh.String(),                   // From MockGetVulnerabilityByID - Added Likelihood
+		Access:         enums.AccessTypeNetwork.String(),                    // From MockGetVulnerabilityByID
+		Complexity:     enums.ComplexityTypeLow.String(),                    // From MockGetVulnerabilityByID - Added Complexity
+		Privileges:     enums.PrivilegesRequiredHigh.String(),               // From MockGetVulnerabilityByID - Added PrivilegesRequired
+		Exploitability: enums.ExploitabilityTypeFunctional.String(),         // From MockGetVulnerabilityByID
+		Comment:        "Wow you should really do something about this one", // From MockGetVulnerabilityByID
+		Recommendation: "",                                                  // TODO: Populate this field with vendor recommendation, if any - No mock data for recommendation
+		References:     []string{"https://vulners.com/cve/CVE-2021-25216"},  // From MockGetVulnerabilityByID
+		DateInfo: domain.DateInfo{
+			Published:   time.Date(2014, time.August, 10, 10, 10, 0, 0, time.Local), // From MockGetVulnerabilityByID
+			LastUpdated: time.Date(2014, time.August, 10, 10, 10, 0, 0, time.Local), // From MockGetVulnerabilityByID
+		},
+		PluginInfo: domain.PluginInfo{
+			CPE:      "cpe:/o:test:testos:1.0",            // From MockGetOSByID
+			Severity: enums.SeverityTypeCritical.String(), // From MockGetVulnerabilityByID
+			Version:  "cpe:/o:test:testos:1.0",            // From MockGetOSByID - Version is CPE? Review mapping
+			Type:     "Linux",                             // From MockGetOSByID
+			Family:   "",                                  // getPluginInfoForOS does not map Family from OSData in mock setup
+		},
+		VPRKeyD: domain.VPRKeyInfo{
+			ThreatIntensity: enums.SeverityTypeCritical.String(),                                                      // From MockGetVulnerabilityByID
+			ExploitMaturity: enums.ExploitabilityTypeFunctional.String(),                                              // From MockGetVulnerabilityByID
+			VulnAge:         calculateVulnerabiltyAgeDays(time.Date(2014, time.August, 10, 10, 10, 0, 0, time.Local)), // From MockGetVulnerabilityByID
+			ProductCoverage: enums.ImpactTypeNone.String(),                                                            // From MockGetVulnerabilityByID
+		},
+		RiskInfo: domain.RiskInfo{
+			RiskScore:          20.5,                             // From MockGetVulnerabilityByID - Updated to match image
+			AvailabilityImpact: enums.ImpactTypeNone.String(),    // From MockGetVulnerabilityByID
+			IntegrityImpact:    enums.ImpactTypeHigh.String(),    // From MockGetVulnerabilityByID
+			CVSSV3Base:         5.5,                              // From MockGetVulnerabilityByID
+			CVSSV30Vector:      enums.AccessTypeNetwork.String(), // From MockGetVulnerabilityByID - Correct mapping?
+		},
+	}
+
+	assert.Equal(t, expectedDetail, vulnDetail)
+}

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/domain"
 )
 
@@ -234,4 +236,87 @@ func (s *PostgreSQLStore) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vu
 	}
 
 	return vulners, nil
+}
+
+func (s *PostgreSQLStore) GetVulnerabilityByID(vulnID int) (*domain.Vulnerability, error) {
+	query := `
+      SELECT 
+          id,
+          vulnerability_id,
+          scan_id,
+          host_id,
+          "type",
+          cvss,
+          vuln_references,
+          created_at,
+          updated_at,
+          severity,
+          analyst_comment,
+          operating_system_id,
+          service_id,
+          description,
+          access_type,
+          complexity,
+          privileges_required,
+          likelihood,
+          risk_score,
+          impact_score,
+          exploit_score,
+          exploitability,
+          integrity_impact,
+          availability_impact,
+          base_severity,
+          published,
+          last_updated
+      FROM scan_vulnerabilities
+      WHERE id = $1
+  `
+
+	var vuln domain.Vulnerability
+	var referencesBytes []byte
+	var exploit tools.Exploit
+
+	err := s.db.QueryRow(query, vulnID).Scan(
+		&vuln.ID,
+		&vuln.VulnerabilityID,
+		&vuln.ScanID,
+		&vuln.HostID,
+		&vuln.Type,
+		&vuln.BaseCVSSScore,
+		&referencesBytes,
+		&vuln.CreatedAt,
+		&vuln.UpdatedAt,
+		&vuln.Severity,
+		&vuln.AnalystComment,
+		&vuln.OperatingSystemID,
+		&vuln.ServiceID,
+		&vuln.Description,
+		&vuln.AccessType,
+		&vuln.Complexity,
+		&vuln.PrivilegesRequired,
+		&vuln.Likelihood,
+		&vuln.RiskScore,
+		&vuln.ImpactScore,
+		&exploit.Score,
+		&exploit.Exploitability,
+		&vuln.IntegrityImpact,
+		&vuln.AvailabilityImpact,
+		&vuln.BaseSeverity,
+		&vuln.Published,
+		&vuln.LastUpdated,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w %d: %w", customerrors.ErrVulnNotFound, vulnID, err)
+		}
+		return nil, fmt.Errorf("error scanning into vulnerability: %w", err)
+	}
+
+	if err := json.Unmarshal(referencesBytes, &vuln.References); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal referencesBytes: %w", err)
+	}
+
+	vuln.Exploit = exploit
+
+	return &vuln, nil
 }


### PR DESCRIPTION
## 🛡️ New Endpoint: api/vulnerability/{id}

This PR introduces the `api/vulnerability/{id}` endpoint, which the detail for a vulnerability which was found during a scan. A vulnerability can be associated to a _service_ (running on a specific port) or an _operating system_. This endpoint show's data for the vulnerability and some metadata regarding the port/service/os , host and scan.

## 🗂️ Storage Layer Enhancements

* Add GetVulnerabilityByID method

## 🔧 Service Layer Enhancements

* Added `vulnerability service` and unit tests for it's `GetVulnerability` method. This service and it's handler follow the Dependency Injection principles we've been working with during development.

## ♻️ Code Refactor: Storage mocks

* Created a new package dedicated for **mocks** (so that we can share mocks across test files). Moved the storage mock over there.