### PR TITLE
Feature/kt 370 implement main dashboard endpoints

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -94,7 +94,7 @@ func (s *APIServer) Init() error {
 
 	router.HandleFunc("GET /api/vulnerabilities/{id}", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.vulnHandlers.GetVulnerability), "getVulnerability"))
 
-	router.HandleFunc("GET /api/dashboard", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.hostHandlers.GetDashboard), "getDashboard"))
+	router.HandleFunc("GET /api/dashboard", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.tenantHandlers.GetDashboard), "getDashboard"))
 
 	stack := middleware.CreateStack(
 		middleware.Logging,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -94,6 +94,8 @@ func (s *APIServer) Init() error {
 
 	router.HandleFunc("GET /api/vulnerabilities/{id}", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.vulnHandlers.GetVulnerability), "getVulnerability"))
 
+	router.HandleFunc("GET /api/dashboard", s.authHandlers.WithAuth(makeHTTPHandlerFunc(s.hostHandlers.GetDashboard), "getDashboard"))
+
 	stack := middleware.CreateStack(
 		middleware.Logging,
 		middleware.CheckCORS,

--- a/pkg/customerrors/dashboard.go
+++ b/pkg/customerrors/dashboard.go
@@ -1,0 +1,5 @@
+package customerrors
+
+import "errors"
+
+var ErrInvalidTimePeriodFilter = errors.New("invalid time period filter")

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -1,6 +1,32 @@
 package domain
 
-import "github.com/kptm-tools/common/common/pkg/results/tools"
+import (
+	"time"
+
+	"github.com/kptm-tools/common/common/pkg/results/tools"
+)
+
+type TenantDashboardData struct {
+	OverallSecurityPosture           OverallSecurityPostureData
+	HostSeverityHeatMap              HostSeverityHeatMapData
+	VulnerabilityTrends              []ServiceTimePeriod
+	LastScan                         *LastScanData
+	VulnerabilitySeverityCount       tools.SeverityCounts
+	HostsWithGreatestVulnerabilities map[string]int
+}
+
+type OverallSecurityPostureData struct {
+	Score     float64
+	Variation float64
+}
+
+type LastScanData struct {
+	HostAlias                     string
+	TotalVulnerabilities          int
+	TotalVulnerabilitiesVariation int
+	SeverityCounts                tools.SeverityCounts
+	ScanDate                      time.Time
+}
 
 // HostSeverityHeatMapData is a map where keys are hostnames (strings)
 // and values are tools.SeverityCounts, representing vulnerability counts

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -76,7 +76,7 @@ type HostAliasSeverityCountPair struct {
 	SeverityCount tools.SeverityCounts
 }
 
-// HostAliasSeverityVulnerabilityPair is a struct where keys are hostnames (strings)
+// HostAliasVulnerabilityPair is a struct where keys are hostnames (strings)
 // and values represent total vulnerability counts for the latest scan in that host.
 type HostAliasVulnerabilityPair struct {
 	Alias              string

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -1,0 +1,8 @@
+package domain
+
+import "github.com/kptm-tools/common/common/pkg/results/tools"
+
+// HostSeverityHeatMapData is a map where keys are hostnames (strings)
+// and values are tools.SeverityCounts, representing vulnerability counts
+// per severity.
+type HostSeverityHeatMapData map[string]tools.SeverityCounts

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/kptm-tools/common/common/pkg/results/tools"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
 )
 
 type TimePeriodFilter string
@@ -16,6 +17,21 @@ const (
 
 func (t TimePeriodFilter) String() string {
 	return string(t)
+}
+
+// ParseTimePeriodFilter parses a string into a TimePeriodFilter enum.
+// It returns an error if the string is not a valid TimePeriodFilter value.
+func ParseTimePeriodFilter(s string) (TimePeriodFilter, error) {
+	switch s {
+	case "Month":
+		return TimePeriodFilterMonth, nil
+	case "Quarter":
+		return TimePeriodFilterQuarter, nil
+	case "Semester":
+		return TimePeriodFilterSemester, nil
+	default:
+		return TimePeriodFilterMonth, customerrors.ErrInvalidTimePeriodFilter
+	}
 }
 
 // GetOrderedTimePeriods returns a slice of ordered time periods based on the TimePeriodFilter

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -12,7 +12,7 @@ type TenantDashboardData struct {
 	VulnerabilityTrends              []ServiceTimePeriod
 	LastScan                         *LastScanData
 	VulnerabilitySeverityCount       tools.SeverityCounts
-	HostsWithGreatestVulnerabilities map[string]int
+	HostsWithGreatestVulnerabilities []HostAliasVulnerabilityPair
 }
 
 type OverallSecurityPostureData struct {
@@ -32,3 +32,8 @@ type LastScanData struct {
 // and values are tools.SeverityCounts, representing vulnerability counts
 // per severity.
 type HostSeverityHeatMapData map[string]tools.SeverityCounts
+
+type HostAliasVulnerabilityPair struct {
+	Alias              string
+	VulnerabilityCount int
+}

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -64,37 +64,37 @@ func getSemestersInOrder() []string {
 }
 
 type TenantDashboardData struct {
-	OverallSecurityPosture           OverallSecurityPostureData
-	HostSeverityHeatMap              []HostAliasSeverityCountPair
-	VulnerabilityTrends              []ServiceTimePeriod
-	LastScan                         *LastScanData
-	HostsWithGreatestVulnerabilities []HostAliasVulnerabilityPair
+	OverallSecurityPosture           OverallSecurityPostureData   `json:"overall_security_posture"`
+	HostSeverityHeatMap              []HostAliasSeverityCountPair `json:"host_severit_heat_map"`
+	VulnerabilityTrends              []ServiceTimePeriod          `json:"vulnerability_trends"`
+	LastScan                         *LastScanData                `json:"last_scan"`
+	HostsWithGreatestVulnerabilities []HostAliasVulnerabilityPair `json:"hosts_with_greatest_vulnerabilities"`
 }
 
 type OverallSecurityPostureData struct {
-	Score     float64
-	Variation float64
+	Score     float64 `json:"score"`
+	Variation float64 `json:"variation"`
 }
 
 type LastScanData struct {
-	HostAlias                     string
-	TotalVulnerabilities          int
-	TotalVulnerabilitiesVariation int
-	SeverityCounts                tools.SeverityCounts
-	ScanDate                      time.Time
+	HostAlias                     string               `json:"host_alias"`
+	TotalVulnerabilities          int                  `json:"total_vulnerabilities"`
+	TotalVulnerabilitiesVariation int                  `json:"total_vulnerabilities_variation"`
+	SeverityCounts                tools.SeverityCounts `json:"severity_counts"`
+	ScanDate                      time.Time            `json:"scan_date"`
 }
 
 // HostAliasSeverityCountPair is a struct where keys are hostnames (strings)
 // and values are tools.SeverityCounts, representing vulnerability counts
 // per severity.
 type HostAliasSeverityCountPair struct {
-	Alias         string
-	SeverityCount tools.SeverityCounts
+	Alias         string               `json:"alias"`
+	SeverityCount tools.SeverityCounts `json:"severity_count"`
 }
 
 // HostAliasVulnerabilityPair is a struct where keys are hostnames (strings)
 // and values represent total vulnerability counts for the latest scan in that host.
 type HostAliasVulnerabilityPair struct {
-	Alias              string
-	VulnerabilityCount int
+	Alias              string `json:"alias"`
+	VulnerabilityCount int    `json:"vulnerability_count"`
 }

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -8,10 +8,9 @@ import (
 
 type TenantDashboardData struct {
 	OverallSecurityPosture           OverallSecurityPostureData
-	HostSeverityHeatMap              HostSeverityHeatMapData
+	HostSeverityHeatMap              []HostAliasSeverityCountPair
 	VulnerabilityTrends              []ServiceTimePeriod
 	LastScan                         *LastScanData
-	VulnerabilitySeverityCount       tools.SeverityCounts
 	HostsWithGreatestVulnerabilities []HostAliasVulnerabilityPair
 }
 
@@ -28,11 +27,16 @@ type LastScanData struct {
 	ScanDate                      time.Time
 }
 
-// HostSeverityHeatMapData is a map where keys are hostnames (strings)
+// HostAliasSeverityCountPair is a struct where keys are hostnames (strings)
 // and values are tools.SeverityCounts, representing vulnerability counts
 // per severity.
-type HostSeverityHeatMapData map[string]tools.SeverityCounts
+type HostAliasSeverityCountPair struct {
+	Alias         string
+	SeverityCount tools.SeverityCounts
+}
 
+// HostAliasSeverityVulnerabilityPair is a struct where keys are hostnames (strings)
+// and values represent total vulnerability counts for the latest scan in that host.
 type HostAliasVulnerabilityPair struct {
 	Alias              string
 	VulnerabilityCount int

--- a/pkg/domain/dashboard.go
+++ b/pkg/domain/dashboard.go
@@ -6,6 +6,47 @@ import (
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 )
 
+type TimePeriodFilter string
+
+const (
+	TimePeriodFilterMonth    TimePeriodFilter = "Month"
+	TimePeriodFilterQuarter  TimePeriodFilter = "Quarter"
+	TimePeriodFilterSemester TimePeriodFilter = "Semester"
+)
+
+func (t TimePeriodFilter) String() string {
+	return string(t)
+}
+
+// GetOrderedTimePeriods returns a slice of ordered time periods based on the TimePeriodFilter
+func (t TimePeriodFilter) GetOrderedTimePeriods() []string {
+	switch t {
+	case TimePeriodFilterMonth:
+		return getMonthsInOrder()
+	case TimePeriodFilterQuarter:
+		return getQuartersInOrder()
+	case TimePeriodFilterSemester:
+		return getSemestersInOrder()
+	default:
+		return getMonthsInOrder()
+	}
+}
+
+func getMonthsInOrder() []string {
+	return []string{
+		"January", "February", "March", "April", "May", "June",
+		"July", "August", "September", "October", "November", "December",
+	}
+}
+
+func getQuartersInOrder() []string {
+	return []string{"Q1", "Q2", "Q3", "Q4"}
+}
+
+func getSemestersInOrder() []string {
+	return []string{"Semester 1", "Semester 2"}
+}
+
 type TenantDashboardData struct {
 	OverallSecurityPosture           OverallSecurityPostureData
 	HostSeverityHeatMap              []HostAliasSeverityCountPair

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -69,6 +69,7 @@ func GetValidRoles(funcName string) ([]Role, error) {
 		"deleteScheduleByID":              {RoleOperator, RoleAnalyst},
 		"patchScheduleByID":               {RoleOperator, RoleAnalyst},
 		"getSchedules":                    {RoleOperator, RoleAnalyst},
+		"getDashboard":                    {RoleOperator, RoleAnalyst},
 	}
 
 	v, ok := funcRoles[funcName]

--- a/pkg/domain/scan.go
+++ b/pkg/domain/scan.go
@@ -102,8 +102,8 @@ type ServiceVulnerabilityTrends struct {
 }
 
 type ServiceTimePeriod struct {
-	TimePeriod         string
-	VulnerabilityCount int
+	TimePeriod         string `json:"time_period"`
+	VulnerabilityCount int    `json:"vulnerability_count"`
 }
 
 func NewScan(startedAt time.Time) *Scan {

--- a/pkg/handlers/host.go
+++ b/pkg/handlers/host.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -220,19 +219,4 @@ func (h *HostHandlers) ValidateAlias(w http.ResponseWriter, req *http.Request) e
 		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{Error: err.Error()})
 	}
 	return api.WriteJSON(w, http.StatusOK, http.StatusText(http.StatusOK))
-}
-
-func (h *HostHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) error {
-	tenantIDStr := req.Context().Value(middleware.ContextTenantID).(string)
-
-	_, err := h.hostService.GetTenantDashboardData(tenantIDStr)
-	if err != nil {
-		slog.Error("Error getting tenant dashboard data",
-			slog.String("tenant_id", tenantIDStr),
-			slog.Any("error", err))
-		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{
-			Error: http.StatusText(http.StatusInternalServerError),
-		})
-	}
-	return api.WriteJSON(w, http.StatusUnprocessableEntity, "IMPLEMENTATION PENDING")
 }

--- a/pkg/handlers/host.go
+++ b/pkg/handlers/host.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -219,4 +220,19 @@ func (h *HostHandlers) ValidateAlias(w http.ResponseWriter, req *http.Request) e
 		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{Error: err.Error()})
 	}
 	return api.WriteJSON(w, http.StatusOK, http.StatusText(http.StatusOK))
+}
+
+func (h *HostHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) error {
+	tenantIDStr := req.Context().Value(middleware.ContextTenantID).(string)
+
+	_, err := h.hostService.GetTenantDashboardData(tenantIDStr)
+	if err != nil {
+		slog.Error("Error getting tenant dashboard data",
+			slog.String("tenant_id", tenantIDStr),
+			slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{
+			Error: http.StatusText(http.StatusInternalServerError),
+		})
+	}
+	return api.WriteJSON(w, http.StatusUnprocessableEntity, "IMPLEMENTATION PENDING")
 }

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -196,33 +195,15 @@ func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r 
 		slog.Error("failed to extract scanID", slog.Any("err", err))
 	}
 
-	timePeriodFilter := domain.TimePeriodFilterMonth
-	timePeriodFilterStr := r.URL.Query().Get("time_period")
-	if timePeriodFilterStr != "" {
-		timePeriodFilter, err = domain.ParseTimePeriodFilter(timePeriodFilterStr)
-		if err != nil {
-			slog.Warn("Invalid time_period filter query param",
-				slog.String("time_period_filter", timePeriodFilterStr))
-			return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
-		}
+	timePeriodFilter, err := parseTimePeriodFilterFromURLQuery(r, "time_period")
+	if err != nil {
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
 	}
 
-	severityFilterStr := r.URL.Query().Get("severity")
-	var severityFilters []string
-	if severityFilterStr != "" {
-		severityFilters = strings.Split(severityFilterStr, ",")
-		validSeverities := map[string]bool{
-			"low":      true,
-			"medium":   true,
-			"high":     true,
-			"critical": true,
-		}
-		for i, severity := range severityFilters {
-			if !validSeverities[strings.ToLower(severity)] {
-				return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid severity filter. Allowed values: Critical,High,Medium,Low"})
-			}
-			severityFilters[i] = strings.ToLower(severity)
-		}
+	severityFilters, err := parseSeverityFilterFromURLQuery(r, "severity")
+	if err != nil {
+		slog.Warn("Error parsing severity filter", slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid severity filter. Allowed values: Critical,High,Medium,Low"})
 	}
 
 	summaryData, err := h.scanService.GetScanVulnerabilitySummaryByID(scanID, timePeriodFilter, severityFilters)

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -196,16 +196,15 @@ func (h *ScanHandlers) GetScanVulnerabilitySummaryByID(w http.ResponseWriter, r 
 		slog.Error("failed to extract scanID", slog.Any("err", err))
 	}
 
-	timePeriodFilter := r.URL.Query().Get("time_period")
-	if timePeriodFilter == "" {
-		timePeriodFilter = "Month"
-	}
-
-	validTimePeriods := map[string]bool{"Month": true, "Quarter": true, "Semester": true}
-	if !validTimePeriods[timePeriodFilter] {
-		slog.Warn("Invalid time_period filter",
-			slog.String("time_period_filter", timePeriodFilter))
-		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
+	timePeriodFilter := domain.TimePeriodFilterMonth
+	timePeriodFilterStr := r.URL.Query().Get("time_period")
+	if timePeriodFilterStr != "" {
+		timePeriodFilter, err = domain.ParseTimePeriodFilter(timePeriodFilterStr)
+		if err != nil {
+			slog.Warn("Invalid time_period filter query param",
+				slog.String("time_period_filter", timePeriodFilterStr))
+			return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
+		}
 	}
 
 	severityFilterStr := r.URL.Query().Get("severity")

--- a/pkg/handlers/tenant.go
+++ b/pkg/handlers/tenant.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/kptm-tools/core-service/pkg/api"
+	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 	"github.com/kptm-tools/core-service/pkg/middleware"
 )
@@ -33,7 +37,24 @@ func (h *TenantHandlers) GetTenants(w http.ResponseWriter, req *http.Request) er
 func (h *TenantHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) error {
 	tenantIDStr := req.Context().Value(middleware.ContextTenantID).(string)
 
-	tenantDasboardData, err := h.tenantService.GetTenantDashboardData(tenantIDStr)
+	hostIDFilter, err := parseHostsIDFilterFromURLQuery(req, "host_ids")
+	if err != nil {
+		slog.Warn("Error parsing hostsIDFilter", slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid host_ids filter. Must be comma-separated int e.g: '1,2,3,4'"})
+	}
+
+	trendsTimePeriodFilter, err := parseTimePeriodFilterFromURLQuery(req, "trends_time_period")
+	if err != nil {
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid time_period filter Must be 'Month', 'Quarter', or 'Semester'"})
+	}
+
+	trendsSeverityFilter, err := parseSeverityFilterFromURLQuery(req, "trends_severity")
+	if err != nil {
+		slog.Warn("Error parsing severity filter", slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusBadRequest, api.APIError{Error: "Invalid severity filter. Allowed values: Critical,High,Medium,Low"})
+	}
+
+	tenantDasboardData, err := h.tenantService.GetTenantDashboardData(tenantIDStr, trendsTimePeriodFilter, trendsSeverityFilter, hostIDFilter)
 	if err != nil {
 		slog.Error("Error getting tenant dashboard data",
 			slog.String("tenant_id", tenantIDStr),
@@ -43,5 +64,60 @@ func (h *TenantHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) 
 		})
 	}
 
-	return api.WriteJSON(w, http.StatusUnprocessableEntity, tenantDasboardData)
+	return api.WriteJSON(w, http.StatusOK, tenantDasboardData)
+}
+
+func parseTimePeriodFilterFromURLQuery(req *http.Request, queryKey string) (domain.TimePeriodFilter, error) {
+	var err error
+	timePeriodFilter := domain.TimePeriodFilterMonth
+
+	timePeriodFilterStr := req.URL.Query().Get(queryKey)
+	if timePeriodFilterStr != "" {
+		timePeriodFilter, err = domain.ParseTimePeriodFilter(timePeriodFilterStr)
+		if err != nil {
+			slog.Warn("Invalid time_period filter query param",
+				slog.String("time_period_filter", timePeriodFilterStr))
+			return domain.TimePeriodFilterMonth, err
+		}
+	}
+	return timePeriodFilter, nil
+}
+
+func parseSeverityFilterFromURLQuery(req *http.Request, queryKey string) ([]string, error) {
+	severityFilterStr := req.URL.Query().Get(queryKey)
+	var severityFilters []string
+	if severityFilterStr != "" {
+		severityFilters = strings.Split(severityFilterStr, ",")
+		validSeverities := map[string]bool{
+			"low":      true,
+			"medium":   true,
+			"high":     true,
+			"critical": true,
+		}
+		for i, severity := range severityFilters {
+			if !validSeverities[strings.ToLower(severity)] {
+				return nil, fmt.Errorf("invalid severity filter: %s", severity)
+			}
+			severityFilters[i] = strings.ToLower(severity)
+		}
+	}
+
+	return severityFilters, nil
+}
+
+func parseHostsIDFilterFromURLQuery(req *http.Request, queryKey string) ([]int, error) {
+	hostIDFilter := req.URL.Query().Get(queryKey)
+
+	var hostIDs []int
+	if hostIDFilter != "" {
+		for _, hostIDStr := range strings.Split(hostIDFilter, ",") {
+			hostID, err := strconv.Atoi(hostIDStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid host ID: %s", hostIDStr)
+			}
+			hostIDs = append(hostIDs, hostID)
+		}
+	}
+
+	return hostIDs, nil
 }

--- a/pkg/handlers/tenant.go
+++ b/pkg/handlers/tenant.go
@@ -33,7 +33,7 @@ func (h *TenantHandlers) GetTenants(w http.ResponseWriter, req *http.Request) er
 func (h *TenantHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) error {
 	tenantIDStr := req.Context().Value(middleware.ContextTenantID).(string)
 
-	_, err := h.tenantService.GetTenantDashboardData(tenantIDStr)
+	tenantDasboardData, err := h.tenantService.GetTenantDashboardData(tenantIDStr)
 	if err != nil {
 		slog.Error("Error getting tenant dashboard data",
 			slog.String("tenant_id", tenantIDStr),
@@ -42,5 +42,6 @@ func (h *TenantHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) 
 			Error: http.StatusText(http.StatusInternalServerError),
 		})
 	}
-	return api.WriteJSON(w, http.StatusUnprocessableEntity, "IMPLEMENTATION PENDING")
+
+	return api.WriteJSON(w, http.StatusUnprocessableEntity, tenantDasboardData)
 }

--- a/pkg/handlers/tenant.go
+++ b/pkg/handlers/tenant.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/kptm-tools/core-service/pkg/api"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
+	"github.com/kptm-tools/core-service/pkg/middleware"
 )
 
 type TenantHandlers struct {
@@ -20,12 +22,25 @@ func NewTenantHandlers(tenantService interfaces.ITenantService) *TenantHandlers 
 }
 
 func (h *TenantHandlers) GetTenants(w http.ResponseWriter, req *http.Request) error {
-
 	tenants, err := h.tenantService.GetTenants()
-
 	if err != nil {
 		return api.WriteJSON(w, http.StatusInternalServerError, err.Error())
 	}
 
 	return api.WriteJSON(w, http.StatusOK, tenants)
+}
+
+func (h *TenantHandlers) GetDashboard(w http.ResponseWriter, req *http.Request) error {
+	tenantIDStr := req.Context().Value(middleware.ContextTenantID).(string)
+
+	_, err := h.tenantService.GetTenantDashboardData(tenantIDStr)
+	if err != nil {
+		slog.Error("Error getting tenant dashboard data",
+			slog.String("tenant_id", tenantIDStr),
+			slog.Any("error", err))
+		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{
+			Error: http.StatusText(http.StatusInternalServerError),
+		})
+	}
+	return api.WriteJSON(w, http.StatusUnprocessableEntity, "IMPLEMENTATION PENDING")
 }

--- a/pkg/interfaces/host.go
+++ b/pkg/interfaces/host.go
@@ -16,6 +16,7 @@ type IHostService interface {
 	PatchHostByID(*domain.Host) (*domain.Host, error)
 	ValidateHost(string) error
 	ValidateAlias(string) error
+	GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error)
 }
 
 type IHostHandlers interface {
@@ -26,4 +27,5 @@ type IHostHandlers interface {
 	PatchHostByID(w http.ResponseWriter, req *http.Request) error
 	ValidateHost(w http.ResponseWriter, req *http.Request) error
 	ValidateAlias(w http.ResponseWriter, req *http.Request) error
+	GetDashboard(w http.ResponseWriter, req *http.Request) error
 }

--- a/pkg/interfaces/host.go
+++ b/pkg/interfaces/host.go
@@ -16,7 +16,6 @@ type IHostService interface {
 	PatchHostByID(*domain.Host) (*domain.Host, error)
 	ValidateHost(string) error
 	ValidateAlias(string) error
-	GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error)
 }
 
 type IHostHandlers interface {
@@ -27,5 +26,4 @@ type IHostHandlers interface {
 	PatchHostByID(w http.ResponseWriter, req *http.Request) error
 	ValidateHost(w http.ResponseWriter, req *http.Request) error
 	ValidateAlias(w http.ResponseWriter, req *http.Request) error
-	GetDashboard(w http.ResponseWriter, req *http.Request) error
 }

--- a/pkg/interfaces/scan.go
+++ b/pkg/interfaces/scan.go
@@ -1,9 +1,10 @@
 package interfaces
 
 import (
-	"github.com/kptm-tools/common/common/pkg/results"
 	"net/http"
 	"time"
+
+	"github.com/kptm-tools/common/common/pkg/results"
 
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -23,7 +24,7 @@ type IScanService interface {
 	CalculateProtectionScore(scanID uuid.UUID) (float64, error)
 	GetScanByID(scanID uuid.UUID) (*domain.Scan, error)
 	HandleScanCompletion(scanID uuid.UUID) error
-	GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 	GetAllReportsForTenant(tenantID string) ([]*domain.ReportItem, error)
 	GetScoreCardTrendsForTenant(tenantID string, fromDate, toDate *time.Time) ([]*domain.ScoreCardTrendItem, error)
 	GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulnerability, error)

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -36,6 +36,7 @@ type IStorage interface {
 	GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 	GetReportsByTenantID(string) ([]*domain.ReportItem, error)
 	GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
+	GetScanBeforeLatestByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetScanVulnerabilities(uuid.UUID) ([]*domain.Vulnerability, error)
 	GetScanVulnerabilityCount(uuid.UUID) (int, error)

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -38,6 +38,7 @@ type IStorage interface {
 	GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetScanVulnerabilities(uuid.UUID) ([]*domain.Vulnerability, error)
+	GetScanVulnerabilityCount(uuid.UUID) (int, error)
 	GetSeverityCounts(uuid.UUID) (*tools.SeverityCounts, error)
 	GetVulnerabilityByID(int) (*domain.Vulnerability, error)
 	GetOSByID(int) (*tools.OSData, error)

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -52,4 +52,5 @@ type IStorage interface {
 	PatchScanScheduleByID(int, uuid.UUID, string, bool, string, int, time.Time) error
 	GetCurrentHostIDFromScanSchedule(int) (int, error)
 	ScanScheduleEnableJob(string, bool, int) error
+	GetHostVulnerabilityTrends(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error)
 }

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -33,7 +33,7 @@ type IStorage interface {
 	GetDNSLookupResult(scanID uuid.UUID) (*tools.DNSLookupResult, error)
 	GetHarvesterResult(scanID uuid.UUID) (*tools.HarvesterResult, error)
 	GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error)
-	GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 	GetReportsByTenantID(string) ([]*domain.ReportItem, error)
 	GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	GetScanBeforeLatestByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
@@ -52,5 +52,5 @@ type IStorage interface {
 	PatchScanScheduleByID(int, uuid.UUID, string, bool, string, int, time.Time) error
 	GetCurrentHostIDFromScanSchedule(int) (int, error)
 	ScanScheduleEnableJob(string, bool, int) error
-	GetHostVulnerabilityTrends(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error)
+	GetHostVulnerabilityTrends(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error)
 }

--- a/pkg/interfaces/storage.go
+++ b/pkg/interfaces/storage.go
@@ -11,7 +11,7 @@ import (
 
 type IStorage interface {
 	CreateHost(*domain.Host) (*domain.Host, error)
-	GetHostsByTenantID(string) ([]*domain.Host, error)
+	GetHostsByTenantID(tenantID string, hostsIDFilter []int) ([]*domain.Host, error)
 	GetHostByID(int) (*domain.Host, error)
 	DeleteHostByID(int) (bool, error)
 	PatchHostByID(*domain.Host) (*domain.Host, error)

--- a/pkg/interfaces/tenant.go
+++ b/pkg/interfaces/tenant.go
@@ -9,9 +9,11 @@ import (
 type ITenantService interface {
 	CreateTenant(*domain.Tenant) (*domain.Tenant, error)
 	GetTenants() ([]*domain.Tenant, error)
+	GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error)
 }
 
 type ITenantHandlers interface {
 	// CreateTenant(w http.ResponseWriter, req *http.Request) error
 	GetTenants(w http.ResponseWriter, req *http.Request) error
+	GetDashboard(w http.ResponseWriter, req *http.Request) error
 }

--- a/pkg/interfaces/tenant.go
+++ b/pkg/interfaces/tenant.go
@@ -9,7 +9,7 @@ import (
 type ITenantService interface {
 	CreateTenant(*domain.Tenant) (*domain.Tenant, error)
 	GetTenants() ([]*domain.Tenant, error)
-	GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error)
+	GetTenantDashboardData(tenantID string, trendsTimePeriodFilter domain.TimePeriodFilter, trendsSeverityFilter []string, hostsFilter []int) (*domain.TenantDashboardData, error)
 }
 
 type ITenantHandlers interface {

--- a/pkg/interfaces/tenant.go
+++ b/pkg/interfaces/tenant.go
@@ -12,6 +12,6 @@ type ITenantService interface {
 }
 
 type ITenantHandlers interface {
-	//CreateTenant(w http.ResponseWriter, req *http.Request) error
+	// CreateTenant(w http.ResponseWriter, req *http.Request) error
 	GetTenants(w http.ResponseWriter, req *http.Request) error
 }

--- a/pkg/mocks/host_service.go
+++ b/pkg/mocks/host_service.go
@@ -3,7 +3,8 @@ package mocks
 import "github.com/kptm-tools/core-service/pkg/domain"
 
 type MockHostService struct {
-	MockCreateHost func(host *domain.Host) (*domain.Host, error)
+	MockCreateHost             func(host *domain.Host) (*domain.Host, error)
+	MockGetTenantDashboardData func(string) (*domain.TenantDashboardData, error)
 }
 
 func (m *MockHostService) CreateHost(host *domain.Host) (*domain.Host, error) {
@@ -14,41 +15,48 @@ func (m *MockHostService) CreateHost(host *domain.Host) (*domain.Host, error) {
 }
 
 func (m *MockHostService) GetHostsByTenantID(tenantID string) ([]*domain.Host, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) GetHostByID(ID int) (*domain.Host, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) GetHostNameFromIP(s string) ([]string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) GetDomainIPValues(s string) (*domain.DomainIPResult, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) DeleteHostByID(ID int) (bool, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) PatchHostByID(host *domain.Host) (*domain.Host, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) ValidateHost(s string) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockHostService) ValidateAlias(s string) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
+}
+
+func (m *MockHostService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
+	if m.MockGetTenantDashboardData != nil {
+		return m.MockGetTenantDashboardData(tenantID)
+	}
+	return nil, nil
 }

--- a/pkg/mocks/host_service.go
+++ b/pkg/mocks/host_service.go
@@ -53,10 +53,3 @@ func (m *MockHostService) ValidateAlias(s string) error {
 	// TODO implement me
 	panic("implement me")
 }
-
-func (m *MockHostService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
-	if m.MockGetTenantDashboardData != nil {
-		return m.MockGetTenantDashboardData(tenantID)
-	}
-	return nil, nil
-}

--- a/pkg/mocks/scan_service.go
+++ b/pkg/mocks/scan_service.go
@@ -1,12 +1,13 @@
 package mocks
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/results"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
-	"time"
 )
 
 type MockScanService struct {
@@ -21,91 +22,91 @@ func (m *MockScanService) CreateScan(hostID int, tenantID, operatorID string, st
 }
 
 func (m *MockScanService) GetScans(s string) ([]*domain.ScanSummary, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) InsertScanResult(result *domain.ScanResult) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) InsertVulnerabilityResult(result *domain.ScanResult) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) UpdateScanStatus(scanID uuid.UUID, status enums.ScanStatus) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) MarkScanAsFailed(scanID uuid.UUID) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) MarkScanAsCancelled(scanID uuid.UUID) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetScanInsightsByID(scanID uuid.UUID) (*domain.ScanInsights, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) CalculateProtectionScore(scanID uuid.UUID) (float64, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetScanByID(scanID uuid.UUID) (*domain.Scan, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) HandleScanCompletion(scanID uuid.UUID) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
-func (m *MockScanService) GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
-	//TODO implement me
+func (m *MockScanService) GetScanVulnerabilitySummaryByID(scanID uuid.UUID, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetAllReportsForTenant(tenantID string) ([]*domain.ReportItem, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetScoreCardTrendsForTenant(tenantID string, fromDate, toDate *time.Time) ([]*domain.ScoreCardTrendItem, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulnerability, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) GetSeverityCounts(scanID uuid.UUID) (*tools.SeverityCounts, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) CreateTarget(hostID int) (*results.Target, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) UpdateScanScheduleScanID(scanID uuid.UUID, scanScheduleID int) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *MockScanService) ScanScheduleDisableJob(i int) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -36,6 +36,7 @@ type MockStorage struct {
 	MockGetScanVulnerabilitiesSummary    func(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 	MockGetReportsByTenantID             func(tenantID string) ([]*domain.ReportItem, error)
 	MockGetLatestScanByHostID            func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
+	MockGetScanBeforeLatestByHostID      func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetOldestScanByHostID            func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetScanVulnerabilities           func(uuid.UUID) ([]*domain.Vulnerability, error)
 	MockGetScanVulnerabilityCount        func(uuid.UUID) (int, error)
@@ -231,6 +232,13 @@ func (m *MockStorage) GetReportsByTenantID(tenantID string) ([]*domain.ReportIte
 func (m *MockStorage) GetLatestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
 	if m.MockGetLatestScanByHostID != nil {
 		return m.MockGetLatestScanByHostID(hostID, fromDate, toDate)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) GetScanBeforeLatestByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+	if m.MockGetScanBeforeLatestByHostID != nil {
+		return m.MockGetScanBeforeLatestByHostID(hostID, fromDate, toDate)
 	}
 	return nil, nil
 }

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -52,6 +52,7 @@ type MockStorage struct {
 	MockPatchScanScheduleByID            func(scanScheduleID int, scanID uuid.UUID, cronExpr string, isRepeated bool, periodName string, periodQuantity int, scheduleDate time.Time) error
 	MockGetCurrentHostIDFromScanSchedule func(scanScheduleID int) (int, error)
 	MockScanScheduleEnableJob            func(cronExp string, hasPeriod bool, scanScheduleID int) error
+	MockGetHostVulnerabilityTrends       func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error)
 }
 
 func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
@@ -346,4 +347,11 @@ func (m *MockStorage) ScanScheduleEnableJob(cronExp string, hasPeriod bool, scan
 		return m.MockScanScheduleEnableJob(cronExp, hasPeriod, scanScheduleID)
 	}
 	return nil
+}
+
+func (m *MockStorage) GetHostVulnerabilityTrends(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+	if m.MockGetHostVulnerabilityTrends != nil {
+		return m.MockGetHostVulnerabilityTrends(hostID, timePeriodFilter, severityFilters)
+	}
+	return nil, nil
 }

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -11,7 +11,7 @@ import (
 
 type MockStorage struct {
 	MockCreateHost                       func(*domain.Host) (*domain.Host, error)
-	MockGetHostsByTenantID               func(string) ([]*domain.Host, error)
+	MockGetHostsByTenantID               func(string, []int) ([]*domain.Host, error)
 	MockGetHostByID                      func(int) (*domain.Host, error)
 	MockDeleteHostByID                   func(int) (bool, error)
 	MockPatchHostByID                    func(*domain.Host) (*domain.Host, error)
@@ -62,9 +62,9 @@ func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
 	return nil, nil // Default behavior if mock function not set
 }
 
-func (m *MockStorage) GetHostsByTenantID(arg0 string) ([]*domain.Host, error) {
+func (m *MockStorage) GetHostsByTenantID(arg0 string, arg1 []int) ([]*domain.Host, error) {
 	if m.MockGetHostsByTenantID != nil {
-		return m.MockGetHostsByTenantID(arg0)
+		return m.MockGetHostsByTenantID(arg0, arg1)
 	}
 	return nil, nil // Default behavior if mock function not set
 }

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -38,6 +38,7 @@ type MockStorage struct {
 	MockGetLatestScanByHostID            func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetOldestScanByHostID            func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetScanVulnerabilities           func(uuid.UUID) ([]*domain.Vulnerability, error)
+	MockGetScanVulnerabilityCount        func(uuid.UUID) (int, error)
 	MockGetSeverityCounts                func(uuid.UUID) (*tools.SeverityCounts, error)
 	MockGetOSByID                        func(int) (*tools.OSData, error)
 	MockGetServiceByID                   func(int) (*tools.PortData, error)
@@ -246,6 +247,13 @@ func (m *MockStorage) GetScanVulnerabilities(scanID uuid.UUID) ([]*domain.Vulner
 		return m.MockGetScanVulnerabilities(scanID)
 	}
 	return nil, nil
+}
+
+func (m *MockStorage) GetScanVulnerabilityCount(scanID uuid.UUID) (int, error) {
+	if m.MockGetScanVulnerabilityCount != nil {
+		return m.MockGetScanVulnerabilityCount(scanID)
+	}
+	return 0, nil
 }
 
 func (m *MockStorage) GetSeverityCounts(scanID uuid.UUID) (*tools.SeverityCounts, error) {

--- a/pkg/mocks/storage.go
+++ b/pkg/mocks/storage.go
@@ -33,7 +33,7 @@ type MockStorage struct {
 	MockGetDNSLookupResult               func(scanID uuid.UUID) (*tools.DNSLookupResult, error)
 	MockGetHarvesterResult               func(scanID uuid.UUID) (*tools.HarvesterResult, error)
 	MockGetNmapResult                    func(scanID uuid.UUID) (*tools.NmapResult, error)
-	MockGetScanVulnerabilitiesSummary    func(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
+	MockGetScanVulnerabilitiesSummary    func(scanID uuid.UUID, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error)
 	MockGetReportsByTenantID             func(tenantID string) ([]*domain.ReportItem, error)
 	MockGetLatestScanByHostID            func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
 	MockGetScanBeforeLatestByHostID      func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error)
@@ -52,7 +52,7 @@ type MockStorage struct {
 	MockPatchScanScheduleByID            func(scanScheduleID int, scanID uuid.UUID, cronExpr string, isRepeated bool, periodName string, periodQuantity int, scheduleDate time.Time) error
 	MockGetCurrentHostIDFromScanSchedule func(scanScheduleID int) (int, error)
 	MockScanScheduleEnableJob            func(cronExp string, hasPeriod bool, scanScheduleID int) error
-	MockGetHostVulnerabilityTrends       func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error)
+	MockGetHostVulnerabilityTrends       func(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error)
 }
 
 func (m *MockStorage) CreateHost(arg0 *domain.Host) (*domain.Host, error) {
@@ -216,7 +216,7 @@ func (m *MockStorage) GetNmapResult(scanID uuid.UUID) (*tools.NmapResult, error)
 	return nil, nil // Default behavior if mock function not set
 }
 
-func (m *MockStorage) GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter string, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
+func (m *MockStorage) GetScanVulnerabilitiesSummary(scanID uuid.UUID, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) (*domain.ScanVulnerabilitySummaryData, error) {
 	if m.MockGetScanVulnerabilitiesSummary != nil {
 		return m.MockGetScanVulnerabilitiesSummary(scanID, timePeriodFilter, severityFilters)
 	}
@@ -349,7 +349,7 @@ func (m *MockStorage) ScanScheduleEnableJob(cronExp string, hasPeriod bool, scan
 	return nil
 }
 
-func (m *MockStorage) GetHostVulnerabilityTrends(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+func (m *MockStorage) GetHostVulnerabilityTrends(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
 	if m.MockGetHostVulnerabilityTrends != nil {
 		return m.MockGetHostVulnerabilityTrends(hostID, timePeriodFilter, severityFilters)
 	}

--- a/pkg/mocks/tenant_service.go
+++ b/pkg/mocks/tenant_service.go
@@ -1,0 +1,30 @@
+package mocks
+
+import "github.com/kptm-tools/core-service/pkg/domain"
+
+type MockTenantService struct {
+	MockCreateTenant           func(*domain.Tenant) (*domain.Tenant, error)
+	MockGetTenants             func() ([]*domain.Tenant, error)
+	MockGetTenantDashboardData func(string) (*domain.TenantDashboardData, error)
+}
+
+func (m *MockTenantService) CreateTenant(tenant *domain.Tenant) (*domain.Tenant, error) {
+	if m.MockCreateTenant != nil {
+		return m.MockCreateTenant(tenant)
+	}
+	return nil, nil
+}
+
+func (m MockTenantService) GetTenants() ([]*domain.Tenant, error) {
+	if m.MockGetTenants != nil {
+		return m.MockGetTenants()
+	}
+	return nil, nil
+}
+
+func (m *MockTenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
+	if m.MockGetTenantDashboardData != nil {
+		return m.MockGetTenantDashboardData(tenantID)
+	}
+	return nil, nil
+}

--- a/pkg/samples/scan_results.go
+++ b/pkg/samples/scan_results.go
@@ -427,6 +427,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2017-15715",
 									Type:          "cve",
 									BaseCVSSScore: 9.8,
+									BaseSeverity:  enums.SeverityTypeCritical,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2017-15715"},
 									Exploit: tools.Exploit{
 										Score:          9.8,
@@ -496,6 +497,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2017-15715",
 									Type:          "cve",
 									BaseCVSSScore: 9.8,
+									BaseSeverity:  enums.SeverityTypeCritical,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2017-15715"},
 									Exploit: tools.Exploit{
 										Score:          0.8,
@@ -519,6 +521,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2021-34527", // Example CVE for nginx
 									Type:          "cve",
 									BaseCVSSScore: 7.5,
+									BaseSeverity:  enums.SeverityTypeHigh,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-34527"},
 									Exploit: tools.Exploit{
 										Score:          0.8,
@@ -529,6 +532,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2021-34528", // Another example CVE for nginx
 									Type:          "cve",
 									BaseCVSSScore: 6.5,
+									BaseSeverity:  enums.SeverityTypeMedium,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-34528"},
 									Exploit: tools.Exploit{
 										Score:          0.0,
@@ -598,6 +602,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2020-0601", // Example CVE for IIS
 									Type:          "cve",
 									BaseCVSSScore: 8.8,
+									BaseSeverity:  enums.SeverityTypeHigh,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2020-0601"},
 									Exploit: tools.Exploit{
 										Score:          9.9,
@@ -701,6 +706,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2021-34527",
 									Type:          "cve",
 									BaseCVSSScore: 7.5,
+									BaseSeverity:  enums.SeverityTypeHigh,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-34527"},
 									Exploit: tools.Exploit{
 										Score:          9.9,
@@ -711,6 +717,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2021-34528",
 									Type:          "cve",
 									BaseCVSSScore: 6.5,
+									BaseSeverity:  enums.SeverityTypeMedium,
 									References:    []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-34528"},
 									Exploit: tools.Exploit{
 										Score:          5.0,
@@ -780,6 +787,7 @@ func SampleVulnerabilityAnalysisScanResults(scans []domain.Scan) []domain.ScanRe
 									ID:            "CVE-2023-XXXXX", // Placeholder CVE for embedded device
 									Type:          "cve",
 									BaseCVSSScore: 6.0,
+									BaseSeverity:  enums.SeverityTypeMedium,
 									References:    []string{"https://example.com/embedded-cve"}, // Placeholder URL
 									Exploit: tools.Exploit{
 										Score:          5.0,

--- a/pkg/services/host.go
+++ b/pkg/services/host.go
@@ -223,3 +223,7 @@ func (s *HostService) handleIPType(normalizedURL string) (*domain.DomainIPResult
 		IP:     ipValue,
 	}, nil
 }
+
+func (s *HostService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
+	return nil, fmt.Errorf("Implementation Pending")
+}

--- a/pkg/services/host.go
+++ b/pkg/services/host.go
@@ -39,7 +39,7 @@ func (s *HostService) CreateHost(t *domain.Host) (*domain.Host, error) {
 }
 
 func (s *HostService) GetHostsByTenantID(tenantID string) ([]*domain.Host, error) {
-	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+	hosts, err := s.storage.GetHostsByTenantID(tenantID, []int{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/host.go
+++ b/pkg/services/host.go
@@ -223,7 +223,3 @@ func (s *HostService) handleIPType(normalizedURL string) (*domain.DomainIPResult
 		IP:     ipValue,
 	}, nil
 }
-
-func (s *HostService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
-	return nil, fmt.Errorf("Implementation Pending")
-}

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -225,7 +225,7 @@ func (s *ScanService) GetAllReportsForTenant(tenantID string) ([]*domain.ReportI
 }
 
 func (s *ScanService) GetScoreCardTrendsForTenant(tenantID string, fromDate, toDate *time.Time) ([]*domain.ScoreCardTrendItem, error) {
-	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+	hosts, err := s.storage.GetHostsByTenantID(tenantID, []int{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch hosts for tenant %s: %w", tenantID, err)
 	}

--- a/pkg/services/scan.go
+++ b/pkg/services/scan.go
@@ -197,7 +197,7 @@ func (s *ScanService) HandleScanCompletion(scanID uuid.UUID) error {
 
 func (s *ScanService) GetScanVulnerabilitySummaryByID(
 	scanID uuid.UUID,
-	timePeriodFilter string,
+	timePeriodFilter domain.TimePeriodFilter,
 	severityFilters []string,
 ) (*domain.ScanVulnerabilitySummaryData, error) {
 	slog.Debug("Fetching scan vulnerabilities summary...", slog.String("scan_id", scanID.String()))
@@ -226,7 +226,6 @@ func (s *ScanService) GetAllReportsForTenant(tenantID string) ([]*domain.ReportI
 
 func (s *ScanService) GetScoreCardTrendsForTenant(tenantID string, fromDate, toDate *time.Time) ([]*domain.ScoreCardTrendItem, error) {
 	hosts, err := s.storage.GetHostsByTenantID(tenantID)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch hosts for tenant %s: %w", tenantID, err)
 	}

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -37,14 +37,9 @@ func (s *TenantService) GetTenants() ([]*domain.Tenant, error) {
 
 func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
 	// 1. Get Overall Security Posture (averageProtectionScore)
-	overallSecurityPosture, securityPostureVariation, err := s.GetTenantSecurityPosture(tenantID)
+	securityPostureData, err := s.GetTenantSecurityPosture(tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tenant security posture: %w", err)
-	}
-
-	securityPostureData := domain.OverallSecurityPostureData{
-		Score:     overallSecurityPosture,
-		Variation: securityPostureVariation,
 	}
 
 	// 2. Populate a map[domain.Host]domain.Scan with all latest scans for later reference
@@ -90,7 +85,7 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 	// 6. Calculate HostsWithGreatestVulnerabilities
 
 	dashboardData := domain.TenantDashboardData{
-		OverallSecurityPosture: securityPostureData,
+		OverallSecurityPosture: *securityPostureData,
 		HostSeverityHeatMap:    heatMap,
 		VulnerabilityTrends:    trendsTimePeriods,
 		LastScan:               latestScanData,
@@ -118,10 +113,10 @@ func (s *TenantService) getHostLatestScanMap(hosts []*domain.Host) (map[int]*dom
 	return hostLatestScanMap, nil
 }
 
-func (s *TenantService) GetTenantSecurityPosture(tenantID string) (float64, float64, error) {
+func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.OverallSecurityPostureData, error) {
 	hosts, err := s.storage.GetHostsByTenantID(tenantID)
 	if err != nil {
-		return 0.0, 0.0, fmt.Errorf("failed to get hosts for tenant %s: %w", tenantID, err)
+		return nil, fmt.Errorf("failed to get hosts for tenant %s: %w", tenantID, err)
 	}
 
 	currentScoreSum := 0.0
@@ -171,7 +166,10 @@ func (s *TenantService) GetTenantSecurityPosture(tenantID string) (float64, floa
 
 	variation := currentOverallScore - previousOverallScore
 
-	return currentOverallScore, variation, nil
+	return &domain.OverallSecurityPostureData{
+		Score:     currentOverallScore,
+		Variation: variation,
+	}, nil
 }
 
 func (s *TenantService) getHostSeverityHeatMap(hosts []*domain.Host, hostLatestScanMap map[int]*domain.Scan) (domain.HostSeverityHeatMapData, error) {

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -185,6 +185,9 @@ func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.Overa
 	}, nil
 }
 
+// getHostSeverityHeatMap returns a heatmap with the amount of severities found for each host.
+// In case a host has no scans, it is skipped, to avoid giving the false impression that said host
+// has no vulnerabilities (it just doesn't have data yet).
 func (s *TenantService) getHostSeverityHeatMap(
 	hosts []*domain.Host,
 	hostLatestScanMap map[int]*domain.Scan,

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -147,7 +147,7 @@ func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.Overa
 			)
 			continue
 		}
-		if latestScan != nil {
+		if latestScan != nil && latestScan.ProtectionScore != nil {
 			currentScoreSum += *latestScan.ProtectionScore
 			currentHostCount++
 		}
@@ -161,7 +161,7 @@ func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.Overa
 			)
 			continue
 		}
-		if previousScan != nil {
+		if previousScan != nil && previousScan.ProtectionScore != nil {
 			previousScoreSum += *previousScan.ProtectionScore
 			previousHostCount++
 		}

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"fmt"
+	"log/slog"
 
+	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 )
@@ -33,5 +35,141 @@ func (s *TenantService) GetTenants() ([]*domain.Tenant, error) {
 }
 
 func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
-	return nil, fmt.Errorf("Implementation Pending")
+	// 1. Get Overall Security Posture (averageProtectionScore)
+	overallSecurityPosture, securityPostureVariation, err := s.GetTenantSecurityPosture(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tenant security posture: %w", err)
+	}
+
+	securityPostureData := domain.OverallSecurityPostureData{
+		Score:     overallSecurityPosture,
+		Variation: securityPostureVariation,
+	}
+
+	// 2. Populate a map[domain.Host]domain.Scan with all latest scans for later reference
+	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hosts by tenantID %s: %w", tenantID, err)
+	}
+
+	hostLatestScanMap, err := s.getHostLatestScanMap(hosts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to getHostLatestScanMap: %w", err)
+	}
+
+	// 3. Calculate the Heat Map
+	heatMap, err := s.getHostSeverityHeatMap(hosts, hostLatestScanMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HostSeverityHeatMap: %w", err)
+	}
+
+	// 4. Calculate Overall Vulnerability Trends
+	// 5. Calculate Last Scan's Data
+	// 6. Calculate HostsWithGreatestVulnerabilities
+
+	dashboardData := domain.TenantDashboardData{
+		OverallSecurityPosture: securityPostureData,
+		HostSeverityHeatMap:    heatMap,
+	}
+
+	return &dashboardData, nil
+}
+
+func (s *TenantService) getHostLatestScanMap(hosts []*domain.Host) (map[int]*domain.Scan, error) {
+	hostLatestScanMap := make(map[int]*domain.Scan, len(hosts))
+	for _, host := range hosts {
+		latestScan, err := s.storage.GetLatestScanByHostID(host.ID, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get last scan for host %d: %w", host.ID, err)
+		}
+		if latestScan == nil {
+			slog.Warn(
+				"LatestScan for host is nil",
+				slog.Int("host_id", host.ID),
+			)
+		}
+		hostLatestScanMap[host.ID] = latestScan
+	}
+
+	return hostLatestScanMap, nil
+}
+
+func (s *TenantService) GetTenantSecurityPosture(tenantID string) (float64, float64, error) {
+	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+	if err != nil {
+		return 0.0, 0.0, fmt.Errorf("failed to get hosts for tenant %s: %w", tenantID, err)
+	}
+
+	currentScoreSum := 0.0
+	currentHostCount := 0
+	previousScoreSum := 0.0
+	previousHostCount := 0
+
+	for _, host := range hosts {
+		latestScan, err := s.storage.GetLatestScanByHostID(host.ID, nil, nil)
+		if err != nil {
+			slog.Warn(
+				"Error getting latest scan for host",
+				slog.Int("host_id", host.ID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		if latestScan != nil {
+			currentScoreSum += *latestScan.ProtectionScore
+			currentHostCount++
+		}
+
+		previousScan, err := s.storage.GetScanBeforeLatestByHostID(host.ID, nil, nil)
+		if err != nil {
+			slog.Warn(
+				"Error getting scan before latest for host",
+				slog.Int("host_id", host.ID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		if previousScan != nil {
+			previousScoreSum += *previousScan.ProtectionScore
+			previousHostCount++
+		}
+	}
+
+	var currentOverallScore float64 = 0
+	if currentHostCount > 0 {
+		currentOverallScore = currentScoreSum / float64(currentHostCount)
+	}
+
+	var previousOverallScore float64 = 0
+	if previousHostCount > 0 {
+		previousOverallScore = previousScoreSum / float64(previousHostCount)
+	}
+
+	variation := currentOverallScore - previousOverallScore
+
+	return currentOverallScore, variation, nil
+}
+
+func (s *TenantService) getHostSeverityHeatMap(hosts []*domain.Host, hostLatestScanMap map[int]*domain.Scan) (domain.HostSeverityHeatMapData, error) {
+	severityHeatMap := make(domain.HostSeverityHeatMapData, len(hosts))
+	slog.Debug("GetHostSeverityHeatMap:", slog.Any("host_latest_scan_map", hostLatestScanMap))
+	for _, host := range hosts {
+		if host == nil {
+			continue
+		}
+
+		if scan, ok := hostLatestScanMap[host.ID]; ok {
+			if scan != nil {
+				severityCounts, err := s.storage.GetSeverityCounts(scan.ID)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get host severity counts: %w", err)
+				}
+				severityHeatMap[host.Name] = *severityCounts
+			} else {
+				severityHeatMap[host.Name] = tools.SeverityCounts{}
+			}
+		}
+	}
+
+	return severityHeatMap, nil
 }

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -64,12 +64,23 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 	}
 
 	// 4. Calculate Overall Vulnerability Trends
+	// 4.1 Get a slice with HostIDs to pass to GetHostsVulnerabilityTrends
+	hostIDs := make([]int, 0, len(hosts))
+	for _, host := range hosts {
+		hostIDs = append(hostIDs, host.ID)
+	}
+
+	trendsTimePeriods, err := s.GetHostsVulnerabilityTrends(hostIDs, "Month", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vulnerability trends for hosts: %w", err)
+	}
 	// 5. Calculate Last Scan's Data
 	// 6. Calculate HostsWithGreatestVulnerabilities
 
 	dashboardData := domain.TenantDashboardData{
 		OverallSecurityPosture: securityPostureData,
 		HostSeverityHeatMap:    heatMap,
+		VulnerabilityTrends:    trendsTimePeriods,
 	}
 
 	return &dashboardData, nil
@@ -172,4 +183,35 @@ func (s *TenantService) getHostSeverityHeatMap(hosts []*domain.Host, hostLatestS
 	}
 
 	return severityHeatMap, nil
+}
+
+func (s *TenantService) GetHostsVulnerabilityTrends(
+	hostIDs []int,
+	timePeriodFilter string,
+	severityFilters []string,
+) ([]domain.ServiceTimePeriod, error) {
+	aggregatedTrendsMap := make(map[string]int)
+
+	for _, hostID := range hostIDs {
+		hostTrends, err := s.storage.GetHostVulnerabilityTrends(hostID, timePeriodFilter, severityFilters)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get trends for hostID %d: %w", hostID, err)
+		}
+
+		// Aggregate trends from the current host into the overall map
+		for _, periodData := range hostTrends {
+			aggregatedTrendsMap[periodData.TimePeriod] += periodData.VulnerabilityCount
+		}
+	}
+
+	// Convert the aggregated map to a []domain.ServiceTimePeriod slice
+	var aggregatedTimePeriods []domain.ServiceTimePeriod
+	for timePeriod, vulnCount := range aggregatedTrendsMap {
+		aggregatedTimePeriods = append(aggregatedTimePeriods, domain.ServiceTimePeriod{
+			TimePeriod:         timePeriod,
+			VulnerabilityCount: vulnCount,
+		})
+	}
+
+	return aggregatedTimePeriods, nil
 }

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
@@ -74,13 +75,25 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 	if err != nil {
 		return nil, fmt.Errorf("failed to get vulnerability trends for hosts: %w", err)
 	}
+
 	// 5. Calculate Last Scan's Data
+	latestScans := make([]*domain.Scan, 0, len(hostLatestScanMap))
+	for _, scan := range hostLatestScanMap {
+		latestScans = append(latestScans, scan)
+	}
+
+	latestScanData, err := s.getLatestScanData(latestScans)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest scan data: %w", err)
+	}
+
 	// 6. Calculate HostsWithGreatestVulnerabilities
 
 	dashboardData := domain.TenantDashboardData{
 		OverallSecurityPosture: securityPostureData,
 		HostSeverityHeatMap:    heatMap,
 		VulnerabilityTrends:    trendsTimePeriods,
+		LastScan:               latestScanData,
 	}
 
 	return &dashboardData, nil
@@ -214,4 +227,35 @@ func (s *TenantService) GetHostsVulnerabilityTrends(
 	}
 
 	return aggregatedTimePeriods, nil
+}
+
+func (s *TenantService) getLatestScanData(scans []*domain.Scan) (*domain.LastScanData, error) {
+	// 5.1 Loop over hostLatestScanMap and get the one with the latest date
+	var latestScan domain.Scan
+	var latestDate time.Time
+	for _, scan := range scans {
+		if scan == nil {
+			continue
+		}
+		if scan.StartedAt.After(latestDate) {
+			latestScan = *scan
+			latestDate = scan.StartedAt
+		}
+	}
+
+	// 5.2 Get severity counts for that scan
+	latestScanInsights, err := s.storage.GetScanInsights(latestScan.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get severityCounts for latest scan %s: %w", latestScan.ID.String(), err)
+	}
+
+	latestScanData := domain.LastScanData{
+		HostAlias:                     latestScanInsights.Metadata.HostAlias,
+		TotalVulnerabilities:          latestScanInsights.TotalVulnerabilities,
+		TotalVulnerabilitiesVariation: latestScanInsights.VulnerabilityVariation,
+		SeverityCounts:                latestScanInsights.SeverityCounts,
+		ScanDate:                      latestScanInsights.Metadata.ScanDate,
+	}
+
+	return &latestScanData, nil
 }

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -239,7 +239,7 @@ func (s *TenantService) GetHostsVulnerabilityTrends(
 	}
 
 	for _, hostID := range hostIDs {
-		hostTrends, err := s.storage.GetHostVulnerabilityTrends(hostID, timePeriodFilter.String(), severityFilters)
+		hostTrends, err := s.storage.GetHostVulnerabilityTrends(hostID, timePeriodFilter, severityFilters)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get trends for hostID %d: %w", hostID, err)
 		}

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 )
@@ -36,6 +35,11 @@ func (s *TenantService) GetTenants() ([]*domain.Tenant, error) {
 	return tenants, nil
 }
 
+// GetTenantDashboardData gets the Dashboard data for that Tenant.
+// An important thing to note is that data is seen per host and it's latest scans.
+// If a host has no latest scan, it's data is skipped for certain graphs such as the heatMap
+// and # of vulnerabilities in HostsWithGreatestVulnerabilities, since saying no vulnerabilities
+// were found would be misleading, because the data just doesn't exist at that moment.
 func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
 	// 1. Get Overall Security Posture (averageProtectionScore)
 	securityPostureData, err := s.GetTenantSecurityPosture(tenantID)
@@ -178,24 +182,29 @@ func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.Overa
 	}, nil
 }
 
-func (s *TenantService) getHostSeverityHeatMap(hosts []*domain.Host, hostLatestScanMap map[int]*domain.Scan) (domain.HostSeverityHeatMapData, error) {
-	severityHeatMap := make(domain.HostSeverityHeatMapData, len(hosts))
-	slog.Debug("GetHostSeverityHeatMap:", slog.Any("host_latest_scan_map", hostLatestScanMap))
+func (s *TenantService) getHostSeverityHeatMap(
+	hosts []*domain.Host,
+	hostLatestScanMap map[int]*domain.Scan,
+) ([]domain.HostAliasSeverityCountPair, error) {
+	severityHeatMap := make([]domain.HostAliasSeverityCountPair, 0, len(hosts))
 	for _, host := range hosts {
 		if host == nil {
 			continue
 		}
 
 		if scan, ok := hostLatestScanMap[host.ID]; ok {
-			if scan != nil {
-				severityCounts, err := s.storage.GetSeverityCounts(scan.ID)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get host severity counts: %w", err)
-				}
-				severityHeatMap[host.Name] = *severityCounts
-			} else {
-				severityHeatMap[host.Name] = tools.SeverityCounts{}
+			if scan == nil {
+				continue
 			}
+			severityCounts, err := s.storage.GetSeverityCounts(scan.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get host severity counts: %w", err)
+			}
+			severityHeatMap = append(severityHeatMap,
+				domain.HostAliasSeverityCountPair{
+					Alias:         host.Name,
+					SeverityCount: *severityCounts,
+				})
 		}
 	}
 

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"fmt"
+
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 )
@@ -18,17 +20,18 @@ func NewTenantService(storage interfaces.IStorage) *TenantService {
 }
 
 func (s *TenantService) CreateTenant(t *domain.Tenant) (*domain.Tenant, error) {
-
 	return s.storage.CreateTenant(t)
 }
 
 func (s *TenantService) GetTenants() ([]*domain.Tenant, error) {
-
 	tenants, err := s.storage.GetTenants()
-
 	if err != nil {
 		return nil, err
 	}
 
 	return tenants, nil
+}
+
+func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
+	return nil, fmt.Errorf("Implementation Pending")
 }

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -303,7 +303,10 @@ func (s *TenantService) GetHostsSortedByMostVulnerabilities(
 
 	// Sort in descending order of vulnerability count
 	sort.Slice(hostVulnerabilityPairs, func(i, j int) bool {
-		return hostVulnerabilityPairs[i].VulnerabilityCount > hostVulnerabilityPairs[j].VulnerabilityCount
+		if hostVulnerabilityPairs[i].VulnerabilityCount != hostVulnerabilityPairs[j].VulnerabilityCount {
+			return hostVulnerabilityPairs[i].VulnerabilityCount > hostVulnerabilityPairs[j].VulnerabilityCount
+		}
+		return hostVulnerabilityPairs[i].Alias < hostVulnerabilityPairs[j].Alias
 	})
 
 	return hostVulnerabilityPairs, nil

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -86,6 +86,9 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest scan data: %w", err)
 	}
+	if latestScanData == nil {
+		slog.Warn("Main Dashboard - No latest scan data was found, returning nil")
+	}
 
 	// 6. Calculate HostsWithGreatestVulnerabilities
 	sortedHostsWithGreatestVulnerabilities, err := s.GetHostsSortedByMostVulnerabilities(hosts, hostLatestScanMap)
@@ -97,7 +100,7 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 		OverallSecurityPosture:           *securityPostureData,
 		HostSeverityHeatMap:              heatMap,
 		VulnerabilityTrends:              trendsTimePeriods,
-		LastScan:                         latestScanData,
+		LastScan:                         latestScanData, // Might be nil if there's no last scan
 		HostsWithGreatestVulnerabilities: sortedHostsWithGreatestVulnerabilities,
 	}
 
@@ -244,16 +247,21 @@ func (s *TenantService) GetHostsVulnerabilityTrends(
 
 func (s *TenantService) getLatestScanData(scans []*domain.Scan) (*domain.LastScanData, error) {
 	// 5.1 Loop over hostLatestScanMap and get the one with the latest date
-	var latestScan domain.Scan
-	var latestDate time.Time
+	var latestScan *domain.Scan
+	var latestDate time.Time // Starts as zero-value for time.Time
 	for _, scan := range scans {
 		if scan == nil {
 			continue
 		}
 		if scan.StartedAt.After(latestDate) {
-			latestScan = *scan
+			latestScan = scan
 			latestDate = scan.StartedAt
 		}
+	}
+
+	// If there's no latest scan, return nil
+	if latestScan == nil {
+		return nil, nil
 	}
 
 	// 5.2 Get severity counts for that scan

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/kptm-tools/common/common/pkg/results/tools"
@@ -83,12 +84,17 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 	}
 
 	// 6. Calculate HostsWithGreatestVulnerabilities
+	sortedHostsWithGreatestVulnerabilities, err := s.GetHostsSortedByMostVulnerabilities(hosts, hostLatestScanMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sortedHostsWithGreatesVulnerabilities: %w", err)
+	}
 
 	dashboardData := domain.TenantDashboardData{
-		OverallSecurityPosture: *securityPostureData,
-		HostSeverityHeatMap:    heatMap,
-		VulnerabilityTrends:    trendsTimePeriods,
-		LastScan:               latestScanData,
+		OverallSecurityPosture:           *securityPostureData,
+		HostSeverityHeatMap:              heatMap,
+		VulnerabilityTrends:              trendsTimePeriods,
+		LastScan:                         latestScanData,
+		HostsWithGreatestVulnerabilities: sortedHostsWithGreatestVulnerabilities,
 	}
 
 	return &dashboardData, nil
@@ -256,4 +262,40 @@ func (s *TenantService) getLatestScanData(scans []*domain.Scan) (*domain.LastSca
 	}
 
 	return &latestScanData, nil
+}
+
+func (s *TenantService) GetHostsSortedByMostVulnerabilities(
+	hosts []*domain.Host,
+	latestScanMap map[int]*domain.Scan,
+) ([]domain.HostAliasVulnerabilityPair, error) {
+	var hostVulnerabilityPairs []domain.HostAliasVulnerabilityPair
+
+	// For quick lookup by ID
+	hostMap := make(map[int]*domain.Host)
+	for _, host := range hosts {
+		hostMap[host.ID] = host
+	}
+
+	for hostID, scan := range latestScanMap {
+		if scan == nil {
+			continue
+		}
+
+		host := hostMap[hostID]
+		vulnerabilityCount, err := s.storage.GetScanVulnerabilityCount(scan.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count scan %s vulnerabilities: %w", scan.ID.String(), err)
+		}
+
+		hostVulnerabilityPairs = append(hostVulnerabilityPairs,
+			domain.HostAliasVulnerabilityPair{Alias: host.Name, VulnerabilityCount: vulnerabilityCount},
+		)
+	}
+
+	// Sort in descending order of vulnerability count
+	sort.Slice(hostVulnerabilityPairs, func(i, j int) bool {
+		return hostVulnerabilityPairs[i].VulnerabilityCount > hostVulnerabilityPairs[j].VulnerabilityCount
+	})
+
+	return hostVulnerabilityPairs, nil
 }

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -216,30 +216,40 @@ func (s *TenantService) getHostSeverityHeatMap(
 
 func (s *TenantService) GetHostsVulnerabilityTrends(
 	hostIDs []int,
-	timePeriodFilter string,
+	timePeriodFilter domain.TimePeriodFilter,
 	severityFilters []string,
 ) ([]domain.ServiceTimePeriod, error) {
-	aggregatedTrendsMap := make(map[string]int)
+	orderedTimePeriods := timePeriodFilter.GetOrderedTimePeriods()
+
+	aggregatedTimePeriods := make([]domain.ServiceTimePeriod, len(orderedTimePeriods))
+	for i, period := range orderedTimePeriods {
+		aggregatedTimePeriods[i] = domain.ServiceTimePeriod{
+			TimePeriod:         period,
+			VulnerabilityCount: 0,
+		}
+	}
+
+	// Map for quick lookup of time period index in aggregatedTimePeriods
+	periodIndexMap := make(map[string]int)
+	for i, periodData := range aggregatedTimePeriods {
+		periodIndexMap[periodData.TimePeriod] = i
+	}
 
 	for _, hostID := range hostIDs {
-		hostTrends, err := s.storage.GetHostVulnerabilityTrends(hostID, timePeriodFilter, severityFilters)
+		hostTrends, err := s.storage.GetHostVulnerabilityTrends(hostID, timePeriodFilter.String(), severityFilters)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get trends for hostID %d: %w", hostID, err)
 		}
 
-		// Aggregate trends from the current host into the overall map
+		// Aggregate trends to the pre-ordered slice
 		for _, periodData := range hostTrends {
-			aggregatedTrendsMap[periodData.TimePeriod] += periodData.VulnerabilityCount
+			if index, ok := periodIndexMap[periodData.TimePeriod]; ok {
+				aggregatedTimePeriods[index].VulnerabilityCount += periodData.VulnerabilityCount
+			}
+			slog.Error("Unexpected time period",
+				slog.String("time_period", periodData.TimePeriod),
+				slog.String("time_period_filter", timePeriodFilter.String()))
 		}
-	}
-
-	// Convert the aggregated map to a []domain.ServiceTimePeriod slice
-	var aggregatedTimePeriods []domain.ServiceTimePeriod
-	for timePeriod, vulnCount := range aggregatedTrendsMap {
-		aggregatedTimePeriods = append(aggregatedTimePeriods, domain.ServiceTimePeriod{
-			TimePeriod:         timePeriod,
-			VulnerabilityCount: vulnCount,
-		})
 	}
 
 	return aggregatedTimePeriods, nil

--- a/pkg/services/tenant.go
+++ b/pkg/services/tenant.go
@@ -40,15 +40,20 @@ func (s *TenantService) GetTenants() ([]*domain.Tenant, error) {
 // If a host has no latest scan, it's data is skipped for certain graphs such as the heatMap
 // and # of vulnerabilities in HostsWithGreatestVulnerabilities, since saying no vulnerabilities
 // were found would be misleading, because the data just doesn't exist at that moment.
-func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantDashboardData, error) {
+func (s *TenantService) GetTenantDashboardData(
+	tenantID string,
+	trendsTimePeriodFilter domain.TimePeriodFilter,
+	trendsSeverityFilters []string,
+	hostsIDFilter []int,
+) (*domain.TenantDashboardData, error) {
 	// 1. Get Overall Security Posture (averageProtectionScore)
-	securityPostureData, err := s.GetTenantSecurityPosture(tenantID)
+	securityPostureData, err := s.GetTenantSecurityPosture(tenantID, hostsIDFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tenant security posture: %w", err)
 	}
 
 	// 2. Populate a map[domain.Host]domain.Scan with all latest scans for later reference
-	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+	hosts, err := s.storage.GetHostsByTenantID(tenantID, hostsIDFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hosts by tenantID %s: %w", tenantID, err)
 	}
@@ -71,7 +76,7 @@ func (s *TenantService) GetTenantDashboardData(tenantID string) (*domain.TenantD
 		hostIDs = append(hostIDs, host.ID)
 	}
 
-	trendsTimePeriods, err := s.GetHostsVulnerabilityTrends(hostIDs, "Month", nil)
+	trendsTimePeriods, err := s.GetHostsVulnerabilityTrends(hostIDs, trendsTimePeriodFilter, trendsSeverityFilters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get vulnerability trends for hosts: %w", err)
 	}
@@ -126,8 +131,8 @@ func (s *TenantService) getHostLatestScanMap(hosts []*domain.Host) (map[int]*dom
 	return hostLatestScanMap, nil
 }
 
-func (s *TenantService) GetTenantSecurityPosture(tenantID string) (*domain.OverallSecurityPostureData, error) {
-	hosts, err := s.storage.GetHostsByTenantID(tenantID)
+func (s *TenantService) GetTenantSecurityPosture(tenantID string, hostsIDFilter []int) (*domain.OverallSecurityPostureData, error) {
+	hosts, err := s.storage.GetHostsByTenantID(tenantID, hostsIDFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hosts for tenant %s: %w", tenantID, err)
 	}
@@ -248,10 +253,11 @@ func (s *TenantService) GetHostsVulnerabilityTrends(
 		for _, periodData := range hostTrends {
 			if index, ok := periodIndexMap[periodData.TimePeriod]; ok {
 				aggregatedTimePeriods[index].VulnerabilityCount += periodData.VulnerabilityCount
+			} else {
+				slog.Error("Unexpected time period",
+					slog.String("time_period", periodData.TimePeriod),
+					slog.String("time_period_filter", timePeriodFilter.String()))
 			}
-			slog.Error("Unexpected time period",
-				slog.String("time_period", periodData.TimePeriod),
-				slog.String("time_period_filter", timePeriodFilter.String()))
 		}
 	}
 
@@ -298,7 +304,7 @@ func (s *TenantService) GetHostsSortedByMostVulnerabilities(
 	hosts []*domain.Host,
 	latestScanMap map[int]*domain.Scan,
 ) ([]domain.HostAliasVulnerabilityPair, error) {
-	var hostVulnerabilityPairs []domain.HostAliasVulnerabilityPair
+	hostVulnerabilityPairs := []domain.HostAliasVulnerabilityPair{}
 
 	// For quick lookup by ID
 	hostMap := make(map[int]*domain.Host)

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -343,3 +343,80 @@ func Test_getLatestScanData(t *testing.T) {
 		})
 	}
 }
+
+func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
+	testCases := []struct {
+		name      string // description of this test case
+		mockSetup func(mockStore *mocks.MockStorage)
+		// Named input parameters for target function.
+		hostIDs          []int
+		timePeriodFilter domain.TimePeriodFilter
+		severityFilters  []string
+		want             []domain.ServiceTimePeriod
+		wantErr          bool
+	}{
+		{
+			name: "Two hosts with no timePeriodFilter and no severityFilters",
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+					return []domain.ServiceTimePeriod{
+						{TimePeriod: "January", VulnerabilityCount: 5},
+						{TimePeriod: "February", VulnerabilityCount: 10},
+						{TimePeriod: "March", VulnerabilityCount: 0},
+						{TimePeriod: "April", VulnerabilityCount: 0},
+						{TimePeriod: "May", VulnerabilityCount: 0},
+						{TimePeriod: "June", VulnerabilityCount: 0},
+						{TimePeriod: "July", VulnerabilityCount: 0},
+						{TimePeriod: "Agust", VulnerabilityCount: 0},
+						{TimePeriod: "September", VulnerabilityCount: 0},
+						{TimePeriod: "October", VulnerabilityCount: 0},
+						{TimePeriod: "November", VulnerabilityCount: 0},
+						{TimePeriod: "December", VulnerabilityCount: 0},
+					}, nil
+				}
+			},
+			hostIDs:          []int{1, 2},
+			timePeriodFilter: domain.TimePeriodFilterMonth,
+			severityFilters:  []string{},
+			want: []domain.ServiceTimePeriod{
+				{TimePeriod: "January", VulnerabilityCount: 10},
+				{TimePeriod: "February", VulnerabilityCount: 20},
+				{TimePeriod: "March", VulnerabilityCount: 0},
+				{TimePeriod: "April", VulnerabilityCount: 0},
+				{TimePeriod: "May", VulnerabilityCount: 0},
+				{TimePeriod: "June", VulnerabilityCount: 0},
+				{TimePeriod: "July", VulnerabilityCount: 0},
+				{TimePeriod: "August", VulnerabilityCount: 0},
+				{TimePeriod: "September", VulnerabilityCount: 0},
+				{TimePeriod: "October", VulnerabilityCount: 0},
+				{TimePeriod: "November", VulnerabilityCount: 0},
+				{TimePeriod: "December", VulnerabilityCount: 0},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			s := NewTenantService(mockStore)
+			got, gotErr := s.GetHostsVulnerabilityTrends(tc.hostIDs, tc.timePeriodFilter, tc.severityFilters)
+			if gotErr != nil {
+				if !tc.wantErr {
+					assert.NoError(t, gotErr)
+				}
+				return
+			}
+			if tc.wantErr {
+				assert.Error(t, gotErr)
+			}
+
+			assert.Equal(t, len(tc.want), len(got))
+			for i, wantPeriod := range tc.want {
+				assert.Equal(t, wantPeriod.TimePeriod, got[i].TimePeriod)
+				assert.Equal(t, wantPeriod.VulnerabilityCount, got[i].VulnerabilityCount)
+			}
+		})
+	}
+}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -1,0 +1,175 @@
+package services
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetHostsSortedByMostVulnerabilities(t *testing.T) {
+	testCases := []struct {
+		name               string
+		inputHosts         []*domain.Host
+		inputLatestScanMap map[int]*domain.Scan
+		mockSetup          func(mockStore *mocks.MockStorage)
+		expected           []domain.HostAliasVulnerabilityPair
+		expectErr          bool
+	}{
+		{
+			name: "Two hosts with scans - same vulnerability count",
+			inputHosts: []*domain.Host{
+				{ID: 1, Name: "Host1"},
+				{ID: 2, Name: "Host2"},
+			},
+			inputLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.New()},
+				2: {ID: uuid.New()},
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					return 2, nil
+				}
+			},
+			expected: []domain.HostAliasVulnerabilityPair{
+				{Alias: "Host1", VulnerabilityCount: 2},
+				{Alias: "Host2", VulnerabilityCount: 2},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Two hosts with scans - different vulnerability count",
+			inputHosts: []*domain.Host{
+				{ID: 1, Name: "Host1"},
+				{ID: 2, Name: "Host2"},
+			},
+			inputLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.MustParse("ba40e3a9-50bb-4b0c-b9e6-7a6385f3abbf")},
+				2: {ID: uuid.MustParse("b1596ca0-d48a-4bfd-976a-22afb44f9b06")},
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				scanIDToVulnerabilityCount := make(map[uuid.UUID]int)
+				scanID1 := uuid.MustParse("ba40e3a9-50bb-4b0c-b9e6-7a6385f3abbf")
+				scanID2 := uuid.MustParse("b1596ca0-d48a-4bfd-976a-22afb44f9b06")
+				scanIDToVulnerabilityCount[scanID1] = 5
+				scanIDToVulnerabilityCount[scanID2] = 1
+
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					if vulnCount, ok := scanIDToVulnerabilityCount[scanID]; ok {
+						return vulnCount, nil
+					}
+					return 0, nil
+				}
+			},
+			expected: []domain.HostAliasVulnerabilityPair{
+				{Alias: "Host1", VulnerabilityCount: 5},
+				{Alias: "Host2", VulnerabilityCount: 1},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Hosts with no scans",
+			inputHosts: []*domain.Host{
+				{ID: 1, Name: "Host1"},
+				{ID: 2, Name: "Host2"},
+			},
+			inputLatestScanMap: map[int]*domain.Scan{
+				1: nil,
+				2: nil,
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					return 0, nil
+				}
+			},
+			expected:  []domain.HostAliasVulnerabilityPair{},
+			expectErr: false,
+		},
+		{
+			name: "Mixed hosts with and without scans",
+			inputHosts: []*domain.Host{
+				{ID: 1, Name: "Host1"},
+				{ID: 2, Name: "Host2"},
+			},
+			inputLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.New()},
+				2: nil,
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					return 2, nil
+				}
+			},
+			expected: []domain.HostAliasVulnerabilityPair{
+				{Alias: "Host1", VulnerabilityCount: 2},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Error from GetScanVulnerabilityCount",
+			inputHosts: []*domain.Host{
+				{ID: 1, Name: "Host1"},
+				{ID: 2, Name: "Host2"},
+			},
+			inputLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.New()},
+				2: nil,
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					return 0, customerrors.ErrScanNotFound
+				}
+			},
+			expected:  []domain.HostAliasVulnerabilityPair{},
+			expectErr: true,
+		},
+		{
+			name:               "Empty input hosts and scans",
+			inputHosts:         []*domain.Host{},
+			inputLatestScanMap: map[int]*domain.Scan{},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanVulnerabilityCount = func(scanID uuid.UUID) (int, error) {
+					return 0, nil
+				}
+			},
+			expected:  []domain.HostAliasVulnerabilityPair{},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			tenantService := NewTenantService(mockStore)
+			aliasVulnerPairs, err := tenantService.GetHostsSortedByMostVulnerabilities(tc.inputHosts, tc.inputLatestScanMap)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			fmt.Printf("Got aliasVulnerPairs: %+v\n", aliasVulnerPairs)
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.expected), len(aliasVulnerPairs), "Expected number of HostAliasVulnerabilityPair does not match")
+
+			sort.Slice(tc.expected, func(i, j int) bool {
+				if tc.expected[i].VulnerabilityCount != tc.expected[j].VulnerabilityCount {
+					return tc.expected[i].VulnerabilityCount > tc.expected[j].VulnerabilityCount
+				}
+				return tc.expected[i].Alias < tc.expected[j].Alias
+			})
+
+			for i, expectedPair := range tc.expected {
+				assert.Equal(t, expectedPair.Alias, aliasVulnerPairs[i].Alias, "Alias mismatch at index %d", i)
+				assert.Equal(t, expectedPair.VulnerabilityCount, aliasVulnerPairs[i].VulnerabilityCount, "VulnerabilityCount mismatch at index %d for Alias %s", i, expectedPair.Alias)
+			}
+		})
+	}
+}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/mocks"
@@ -154,8 +156,6 @@ func Test_GetHostsSortedByMostVulnerabilities(t *testing.T) {
 				return
 			}
 
-			fmt.Printf("Got aliasVulnerPairs: %+v\n", aliasVulnerPairs)
-
 			assert.NoError(t, err)
 			assert.Equal(t, len(tc.expected), len(aliasVulnerPairs), "Expected number of HostAliasVulnerabilityPair does not match")
 
@@ -170,6 +170,102 @@ func Test_GetHostsSortedByMostVulnerabilities(t *testing.T) {
 				assert.Equal(t, expectedPair.Alias, aliasVulnerPairs[i].Alias, "Alias mismatch at index %d", i)
 				assert.Equal(t, expectedPair.VulnerabilityCount, aliasVulnerPairs[i].VulnerabilityCount, "VulnerabilityCount mismatch at index %d for Alias %s", i, expectedPair.Alias)
 			}
+		})
+	}
+}
+
+func Test_getLatestScanData(t *testing.T) {
+	timeNow := time.Now().UTC()
+
+	testCases := []struct {
+		name       string
+		inputScans []*domain.Scan
+		mockSetup  func(mockStore *mocks.MockStorage)
+		expected   *domain.LastScanData
+		expectErr  bool
+	}{
+		{
+			name: "Two Valid Scans - Success",
+			inputScans: []*domain.Scan{
+				{
+					ID:        uuid.MustParse("740cc333-80f8-40f0-b14b-466e3cbb77d0"),
+					StartedAt: timeNow,
+				},
+				{
+					ID:        uuid.MustParse("02ac2f74-8a0d-4804-a566-e7c06dfe180e"),
+					StartedAt: timeNow.Add(time.Hour * -24),
+				},
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanInsights = func(scanID uuid.UUID) (*domain.ScanInsights, error) {
+					if scanID == uuid.MustParse("740cc333-80f8-40f0-b14b-466e3cbb77d0") {
+						return &domain.ScanInsights{
+							TotalVulnerabilities:   5,
+							VulnerabilityVariation: 1,
+							SeverityCounts: tools.SeverityCounts{
+								Critical: 1,
+								High:     1,
+								Medium:   1,
+								Low:      1,
+								None:     0,
+								Unknown:  0,
+							},
+							Metadata: domain.ScanInsightsMetadata{
+								HostAlias: "Scan 740cc333-80f8-40f0-b14b-466e3cbb77d0 Host Alias",
+								ScanDate:  timeNow,
+							},
+						}, nil
+					}
+					return nil, fmt.Errorf("No scan insights for scan")
+				}
+			},
+			expected: &domain.LastScanData{
+				HostAlias:                     "Scan 740cc333-80f8-40f0-b14b-466e3cbb77d0 Host Alias",
+				TotalVulnerabilities:          5,
+				TotalVulnerabilitiesVariation: 1,
+				SeverityCounts: tools.SeverityCounts{
+					Critical: 1,
+					High:     1,
+					Medium:   1,
+					Low:      1,
+					None:     0,
+					Unknown:  0,
+				},
+				ScanDate: timeNow,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			tenantService := NewTenantService(mockStore)
+			lastScanData, err := tenantService.getLatestScanData(tc.inputScans)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			// Assert LastScanData is equal to expected struct
+			assert.NotNil(t, lastScanData)
+			assert.Equal(t, tc.expected.HostAlias, lastScanData.HostAlias)
+			assert.Equal(t, tc.expected.TotalVulnerabilities, lastScanData.TotalVulnerabilities)
+			assert.Equal(t, tc.expected.TotalVulnerabilitiesVariation, lastScanData.TotalVulnerabilitiesVariation)
+
+			// SeverityCount sub-struct
+			assert.Equal(t, tc.expected.SeverityCounts.Critical, lastScanData.SeverityCounts.Critical)
+			assert.Equal(t, tc.expected.SeverityCounts.High, lastScanData.SeverityCounts.High)
+			assert.Equal(t, tc.expected.SeverityCounts.Medium, lastScanData.SeverityCounts.Medium)
+			assert.Equal(t, tc.expected.SeverityCounts.Low, lastScanData.SeverityCounts.Low)
+			assert.Equal(t, tc.expected.SeverityCounts.None, lastScanData.SeverityCounts.None)
+			assert.Equal(t, tc.expected.SeverityCounts.Unknown, lastScanData.SeverityCounts.Unknown)
+
+			assert.Equal(t, tc.expected.ScanDate, lastScanData.ScanDate)
 		})
 	}
 }

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -630,3 +630,145 @@ func TestTenantService_getHostSeverityHeatMap(t *testing.T) {
 		})
 	}
 }
+
+func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
+	// mockTenantID := "bca58c71-c268-4c18-aa5b-ecff00d69121"
+	protScore50 := 50.0
+	protScore25 := 25.0
+
+	testCases := []struct {
+		name      string // description of this test case
+		mockSetup func(*mocks.MockStorage)
+		// Named input parameters for target function.
+		tenantID string
+		want     *domain.OverallSecurityPostureData
+		wantErr  bool
+	}{
+		{
+			name: "Tenant with hosts - success",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+						{ID: 2, Name: "Host 2"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: &protScore50}, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: &protScore25}, nil
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     protScore50,
+				Variation: protScore50 - protScore25,
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Tenant with no hosts",
+			mockSetup: func(ms *mocks.MockStorage) {},
+			tenantID:  "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     0.0,
+				Variation: 0.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Tenant hosts with no scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+						{ID: 2, Name: "Host 2"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, nil
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     0.0,
+				Variation: 0.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Tenant hosts with only one scan",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+						{ID: 2, Name: "Host 2"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: &protScore50}, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, nil
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     protScore50,
+				Variation: protScore50, // It increased by 50
+			},
+			wantErr: false,
+		},
+		{
+			name: "Tenant hosts with scans with nil protection scores",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+						{ID: 2, Name: "Host 2"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: nil}, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: nil}, nil
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     0.0,
+				Variation: 0.0,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			s := NewTenantService(mockStore)
+			got, gotErr := s.GetTenantSecurityPosture(tc.tenantID)
+			if gotErr != nil {
+				if !tc.wantErr {
+					assert.NoError(t, gotErr)
+				}
+				return
+			}
+			if tc.wantErr {
+				assert.Error(t, gotErr)
+			}
+
+			assert.NotNil(t, got)
+
+			// Assert OverallSecurityPostureData struct fields
+			assert.Equal(t, tc.want.Score, got.Score, "Expected OverallSecurityPostureData Score %.5f, got %.5f", tc.want.Score, got.Score)
+			assert.Equal(t, tc.want.Variation, got.Variation, "Expected OverallSecurityPostureData Variation %.2f, got %.2f", tc.want.Variation, got.Variation)
+		})
+	}
+}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -812,3 +812,101 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		})
 	}
 }
+
+func TestTenantService_getHostLatestScanMap(t *testing.T) {
+	testCases := []struct {
+		name      string // description of this test case
+		mockSetup func(*mocks.MockStorage)
+		// Named input parameters for target function.
+		hosts   []*domain.Host
+		want    map[int]*domain.Scan
+		wantErr bool
+	}{
+		{
+			name: "Two hosts - Success",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					if hostID == 1 {
+						return &domain.Scan{ID: uuid.MustParse("41fa710c-4539-4e31-9f4a-f333ded62b00"), HostID: 1}, nil
+					}
+					return &domain.Scan{ID: uuid.MustParse("023bf9d4-ac11-4500-a7f1-529fe32dda67"), HostID: 2}, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			want: map[int]*domain.Scan{
+				1: {ID: uuid.MustParse("41fa710c-4539-4e31-9f4a-f333ded62b00"), HostID: 1},
+				2: {ID: uuid.MustParse("023bf9d4-ac11-4500-a7f1-529fe32dda67"), HostID: 2},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Empty Host Slice",
+			mockSetup: func(ms *mocks.MockStorage) {},
+			hosts:     []*domain.Host{},
+			want:      map[int]*domain.Scan{},
+			wantErr:   false,
+		},
+		{
+			name: "Two hosts with no scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			want: map[int]*domain.Scan{
+				1: nil,
+				2: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Storage error fetching latest scan",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, fmt.Errorf("database error")
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			want:    map[int]*domain.Scan{},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			s := NewTenantService(mockStore)
+			got, gotErr := s.getHostLatestScanMap(tc.hosts)
+			if gotErr != nil {
+				if !tc.wantErr {
+					assert.Error(t, gotErr)
+				}
+				return
+			}
+			if tc.wantErr {
+				assert.Error(t, gotErr)
+			}
+
+			assert.Equal(t, len(tc.want), len(got))
+			for _, host := range tc.hosts {
+				assert.Contains(t, got, host.ID, "Expected hostID to be in resulting map keys: %d", host.ID)
+				if scan, ok := got[host.ID]; ok {
+					if scan != nil {
+						assert.Equal(t, scan.HostID, host.ID, "Expected scan HostID and host.ID to match. Got %d want %d", scan.HostID, host.ID)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -235,6 +235,75 @@ func Test_getLatestScanData(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name:       "Nil scans",
+			inputScans: []*domain.Scan{nil, nil},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanInsights = func(scanID uuid.UUID) (*domain.ScanInsights, error) {
+					return nil, nil
+				}
+			},
+			expected:  nil,
+			expectErr: false,
+		},
+		{
+			name: "Scans with same date",
+			inputScans: []*domain.Scan{
+				{
+					ID:        uuid.MustParse("740cc333-80f8-40f0-b14b-466e3cbb77d0"),
+					StartedAt: timeNow,
+				},
+				{
+					ID:        uuid.MustParse("02ac2f74-8a0d-4804-a566-e7c06dfe180e"),
+					StartedAt: timeNow,
+				},
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanInsights = func(scanID uuid.UUID) (*domain.ScanInsights, error) {
+					if scanID == uuid.MustParse("740cc333-80f8-40f0-b14b-466e3cbb77d0") {
+						return &domain.ScanInsights{
+							Metadata: domain.ScanInsightsMetadata{
+								HostAlias: "Host of Scan 740cc333-80f8-40f0-b14b-466e3cbb77d0",
+							},
+						}, nil
+					}
+					return &domain.ScanInsights{}, nil
+				}
+			},
+			// We expect to get the first value of the slice, since we're comparing if
+			// the date is AFTER
+			expected: &domain.LastScanData{
+				HostAlias: "Host of Scan 740cc333-80f8-40f0-b14b-466e3cbb77d0",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Scans Insights Error",
+			inputScans: []*domain.Scan{
+				{
+					ID:        uuid.MustParse("740cc333-80f8-40f0-b14b-466e3cbb77d0"),
+					StartedAt: timeNow,
+				},
+			},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanInsights = func(scanID uuid.UUID) (*domain.ScanInsights, error) {
+					return nil, fmt.Errorf("Error connecting to database")
+				}
+			},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:       "No scans",
+			inputScans: []*domain.Scan{},
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetScanInsights = func(scanID uuid.UUID) (*domain.ScanInsights, error) {
+					return nil, nil
+				}
+			},
+			expected:  nil,
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -250,6 +319,11 @@ func Test_getLatestScanData(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
+
+			if tc.expected == nil {
+				assert.Nil(t, lastScanData)
+				return
+			}
 
 			// Assert LastScanData is equal to expected struct
 			assert.NotNil(t, lastScanData)

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -746,6 +746,46 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Tenant hosts with scans with nil protection scores",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return nil, fmt.Errorf("database error")
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: nil}, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: nil}, nil
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want:     &domain.OverallSecurityPostureData{},
+			wantErr:  true,
+		},
+		{
+			name: "Tenant with hosts but failed to fetch scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+						{ID: 2, Name: "Host 2"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, fmt.Errorf("database error")
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return nil, fmt.Errorf("database error")
+				}
+			},
+			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			want: &domain.OverallSecurityPostureData{
+				Score:     0.0,
+				Variation: 0.0,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -767,7 +807,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 			assert.NotNil(t, got)
 
 			// Assert OverallSecurityPostureData struct fields
-			assert.Equal(t, tc.want.Score, got.Score, "Expected OverallSecurityPostureData Score %.5f, got %.5f", tc.want.Score, got.Score)
+			assert.Equal(t, tc.want.Score, got.Score, "Expected OverallSecurityPostureData Score %.2f, got %.2f", tc.want.Score, got.Score)
 			assert.Equal(t, tc.want.Variation, got.Variation, "Expected OverallSecurityPostureData Variation %.2f, got %.2f", tc.want.Variation, got.Variation)
 		})
 	}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -358,7 +358,7 @@ func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
 		{
 			name: "Two hosts with no timePeriodFilter and no severityFilters",
 			mockSetup: func(mockStore *mocks.MockStorage) {
-				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
 					return []domain.ServiceTimePeriod{
 						{TimePeriod: "January", VulnerabilityCount: 5},
 						{TimePeriod: "February", VulnerabilityCount: 10},
@@ -397,7 +397,7 @@ func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
 		{
 			name: "GetHostVulnerabilityTrends storage error",
 			mockSetup: func(mockStore *mocks.MockStorage) {
-				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
 					return nil, fmt.Errorf("database error")
 				}
 			},
@@ -410,7 +410,7 @@ func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
 		{
 			name: "Empty hostIDs slice",
 			mockSetup: func(mockStore *mocks.MockStorage) {
-				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter domain.TimePeriodFilter, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
 					return nil, fmt.Errorf("database error")
 				}
 			},

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -394,6 +394,45 @@ func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "GetHostVulnerabilityTrends storage error",
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+					return nil, fmt.Errorf("database error")
+				}
+			},
+			hostIDs:          []int{1, 2},
+			timePeriodFilter: domain.TimePeriodFilterMonth,
+			severityFilters:  []string{},
+			want:             nil,
+			wantErr:          true,
+		},
+		{
+			name: "Empty hostIDs slice",
+			mockSetup: func(mockStore *mocks.MockStorage) {
+				mockStore.MockGetHostVulnerabilityTrends = func(hostID int, timePeriodFilter string, severityFilters []string) ([]domain.ServiceTimePeriod, error) {
+					return nil, fmt.Errorf("database error")
+				}
+			},
+			hostIDs:          []int{},
+			timePeriodFilter: domain.TimePeriodFilterMonth,
+			severityFilters:  []string{},
+			want: []domain.ServiceTimePeriod{
+				{TimePeriod: "January", VulnerabilityCount: 0},
+				{TimePeriod: "February", VulnerabilityCount: 0},
+				{TimePeriod: "March", VulnerabilityCount: 0},
+				{TimePeriod: "April", VulnerabilityCount: 0},
+				{TimePeriod: "May", VulnerabilityCount: 0},
+				{TimePeriod: "June", VulnerabilityCount: 0},
+				{TimePeriod: "July", VulnerabilityCount: 0},
+				{TimePeriod: "August", VulnerabilityCount: 0},
+				{TimePeriod: "September", VulnerabilityCount: 0},
+				{TimePeriod: "October", VulnerabilityCount: 0},
+				{TimePeriod: "November", VulnerabilityCount: 0},
+				{TimePeriod: "December", VulnerabilityCount: 0},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -459,3 +459,174 @@ func TestTenantService_GetHostsVulnerabilityTrends(t *testing.T) {
 		})
 	}
 }
+
+func TestTenantService_getHostSeverityHeatMap(t *testing.T) {
+	scan1IDStr := "244cac1f-2c99-41d6-9dc6-ddd3a335ea68"
+	scan2IDStr := "cf243368-c72a-46e0-b042-682883b113cf"
+	testCases := []struct {
+		name      string // description of this test case
+		mockSetup func(*mocks.MockStorage)
+		// Named input parameters for target function.
+		hosts             []*domain.Host
+		hostLatestScanMap map[int]*domain.Scan
+		want              []domain.HostAliasSeverityCountPair
+		wantErr           bool
+	}{
+		{
+			name: "Two hosts with latest scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					if u == uuid.MustParse(scan1IDStr) {
+						return &tools.SeverityCounts{
+							Low: 1,
+						}, nil
+					}
+					return &tools.SeverityCounts{
+						Critical: 5,
+					}, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			hostLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.MustParse(scan1IDStr)},
+				2: {ID: uuid.MustParse(scan2IDStr)},
+			},
+			want: []domain.HostAliasSeverityCountPair{
+				{Alias: "Host 1", SeverityCount: tools.SeverityCounts{Low: 1}},
+				{Alias: "Host 2", SeverityCount: tools.SeverityCounts{Critical: 5}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "One normal host and one nil host",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					if u == uuid.MustParse(scan1IDStr) {
+						return &tools.SeverityCounts{
+							Low: 1,
+						}, nil
+					}
+					return &tools.SeverityCounts{
+						Critical: 5,
+					}, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				nil,
+			},
+			hostLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.MustParse(scan1IDStr)},
+				2: {ID: uuid.MustParse(scan2IDStr)},
+			},
+			want: []domain.HostAliasSeverityCountPair{
+				{Alias: "Host 1", SeverityCount: tools.SeverityCounts{Low: 1}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Two hosts with no scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					if u == uuid.MustParse(scan1IDStr) {
+						return &tools.SeverityCounts{
+							Low: 1,
+						}, nil
+					}
+					return &tools.SeverityCounts{
+						Critical: 5,
+					}, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			hostLatestScanMap: map[int]*domain.Scan{},
+			want:              []domain.HostAliasSeverityCountPair{},
+			wantErr:           false,
+		},
+		{
+			name: "Two hosts with nil scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					return nil, nil
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			hostLatestScanMap: map[int]*domain.Scan{
+				1: nil,
+				2: nil,
+			},
+			want:    []domain.HostAliasSeverityCountPair{},
+			wantErr: false,
+		},
+		{
+			name: "No hosts, no scans",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					return nil, nil
+				}
+			},
+			hosts:             []*domain.Host{},
+			hostLatestScanMap: map[int]*domain.Scan{},
+			want:              []domain.HostAliasSeverityCountPair{},
+			wantErr:           false,
+		},
+		{
+			name: "Storage GetSeverityCounts error",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetSeverityCounts = func(u uuid.UUID) (*tools.SeverityCounts, error) {
+					return nil, fmt.Errorf("database error")
+				}
+			},
+			hosts: []*domain.Host{
+				{ID: 1, Name: "Host 1"},
+				{ID: 2, Name: "Host 2"},
+			},
+			hostLatestScanMap: map[int]*domain.Scan{
+				1: {ID: uuid.MustParse(scan1IDStr)},
+				2: {ID: uuid.MustParse(scan2IDStr)},
+			},
+			want:    []domain.HostAliasSeverityCountPair{},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := &mocks.MockStorage{}
+			tc.mockSetup(mockStore)
+
+			s := NewTenantService(mockStore)
+			got, gotErr := s.getHostSeverityHeatMap(tc.hosts, tc.hostLatestScanMap)
+			if gotErr != nil {
+				if !tc.wantErr {
+					assert.NoError(t, gotErr)
+				}
+				return
+			}
+			if tc.wantErr {
+				assert.Error(t, gotErr)
+			}
+
+			assert.NotNil(t, got)
+			assert.Equal(t, len(tc.want), len(got))
+
+			for i, pair := range tc.want {
+				assert.Equal(t, pair.Alias, got[i].Alias)
+				assert.Equal(t, pair.SeverityCount.Critical, got[i].SeverityCount.Critical)
+				assert.Equal(t, pair.SeverityCount.High, got[i].SeverityCount.High)
+				assert.Equal(t, pair.SeverityCount.Medium, got[i].SeverityCount.Medium)
+				assert.Equal(t, pair.SeverityCount.Low, got[i].SeverityCount.Low)
+				assert.Equal(t, pair.SeverityCount.None, got[i].SeverityCount.None)
+				assert.Equal(t, pair.SeverityCount.Unknown, got[i].SeverityCount.Unknown)
+			}
+		})
+	}
+}

--- a/pkg/services/tenant_test.go
+++ b/pkg/services/tenant_test.go
@@ -640,14 +640,15 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		name      string // description of this test case
 		mockSetup func(*mocks.MockStorage)
 		// Named input parameters for target function.
-		tenantID string
-		want     *domain.OverallSecurityPostureData
-		wantErr  bool
+		tenantID      string
+		hostsIDFilter []int
+		want          *domain.OverallSecurityPostureData
+		wantErr       bool
 	}{
 		{
 			name: "Tenant with hosts - success",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDSFilter []int) ([]*domain.Host, error) {
 					return []*domain.Host{
 						{ID: 1, Name: "Host 1"},
 						{ID: 2, Name: "Host 2"},
@@ -660,7 +661,8 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return &domain.Scan{ProtectionScore: &protScore25}, nil
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     protScore50,
 				Variation: protScore50 - protScore25,
@@ -668,9 +670,10 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "Tenant with no hosts",
-			mockSetup: func(ms *mocks.MockStorage) {},
-			tenantID:  "79541000-de8a-459c-856a-db36563ac4ee",
+			name:          "Tenant with no hosts",
+			mockSetup:     func(ms *mocks.MockStorage) {},
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     0.0,
 				Variation: 0.0,
@@ -680,7 +683,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		{
 			name: "Tenant hosts with no scans",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDsFilter []int) ([]*domain.Host, error) {
 					return []*domain.Host{
 						{ID: 1, Name: "Host 1"},
 						{ID: 2, Name: "Host 2"},
@@ -693,7 +696,8 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return nil, nil
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     0.0,
 				Variation: 0.0,
@@ -703,7 +707,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		{
 			name: "Tenant hosts with only one scan",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDsFilter []int) ([]*domain.Host, error) {
 					return []*domain.Host{
 						{ID: 1, Name: "Host 1"},
 						{ID: 2, Name: "Host 2"},
@@ -716,7 +720,8 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return nil, nil
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     protScore50,
 				Variation: protScore50, // It increased by 50
@@ -726,7 +731,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		{
 			name: "Tenant hosts with scans with nil protection scores",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDsFilter []int) ([]*domain.Host, error) {
 					return []*domain.Host{
 						{ID: 1, Name: "Host 1"},
 						{ID: 2, Name: "Host 2"},
@@ -739,7 +744,8 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return &domain.Scan{ProtectionScore: nil}, nil
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     0.0,
 				Variation: 0.0,
@@ -749,7 +755,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 		{
 			name: "Tenant hosts with scans with nil protection scores",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDsFilter []int) ([]*domain.Host, error) {
 					return nil, fmt.Errorf("database error")
 				}
 				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
@@ -759,14 +765,15 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return &domain.Scan{ProtectionScore: nil}, nil
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
-			want:     &domain.OverallSecurityPostureData{},
-			wantErr:  true,
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
+			want:          &domain.OverallSecurityPostureData{},
+			wantErr:       true,
 		},
 		{
 			name: "Tenant with hosts but failed to fetch scans",
 			mockSetup: func(ms *mocks.MockStorage) {
-				ms.MockGetHostsByTenantID = func(tenantID string) ([]*domain.Host, error) {
+				ms.MockGetHostsByTenantID = func(tenantID string, hostIDsFilter []int) ([]*domain.Host, error) {
 					return []*domain.Host{
 						{ID: 1, Name: "Host 1"},
 						{ID: 2, Name: "Host 2"},
@@ -779,10 +786,34 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 					return nil, fmt.Errorf("database error")
 				}
 			},
-			tenantID: "79541000-de8a-459c-856a-db36563ac4ee",
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{},
 			want: &domain.OverallSecurityPostureData{
 				Score:     0.0,
 				Variation: 0.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Tenant with hosts and host ID filter",
+			mockSetup: func(ms *mocks.MockStorage) {
+				ms.MockGetHostsByTenantID = func(hostID string, hostIDFilter []int) ([]*domain.Host, error) {
+					return []*domain.Host{
+						{ID: 1, Name: "Host 1"},
+					}, nil
+				}
+				ms.MockGetLatestScanByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: &protScore50}, nil
+				}
+				ms.MockGetScanBeforeLatestByHostID = func(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+					return &domain.Scan{ProtectionScore: &protScore25}, nil
+				}
+			},
+			tenantID:      "79541000-de8a-459c-856a-db36563ac4ee",
+			hostsIDFilter: []int{1},
+			want: &domain.OverallSecurityPostureData{
+				Score:     protScore50,
+				Variation: protScore25,
 			},
 			wantErr: false,
 		},
@@ -793,7 +824,7 @@ func TestTenantService_GetTenantSecurityPosture(t *testing.T) {
 			tc.mockSetup(mockStore)
 
 			s := NewTenantService(mockStore)
-			got, gotErr := s.GetTenantSecurityPosture(tc.tenantID)
+			got, gotErr := s.GetTenantSecurityPosture(tc.tenantID, tc.hostsIDFilter)
 			if gotErr != nil {
 				if !tc.wantErr {
 					assert.NoError(t, gotErr)

--- a/pkg/storage/host.go
+++ b/pkg/storage/host.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/lib/pq"
 )
 
 func (s *PostgreSQLStore) ClearHostsTable() error {
@@ -62,14 +63,23 @@ func (s *PostgreSQLStore) CreateHost(t *domain.Host) (*domain.Host, error) {
 	return newHost, nil
 }
 
-func (s *PostgreSQLStore) GetHostsByTenantID(tenantID string) ([]*domain.Host, error) {
+func (s *PostgreSQLStore) GetHostsByTenantID(tenantID string, hostsIDFilter []int) ([]*domain.Host, error) {
+	var rows *sql.Rows
+	var err error
 	query := `
     SELECT *
     FROM hosts
     WHERE tenant_id=$1
   `
 
-	rows, err := s.db.Query(query, tenantID)
+	if len(hostsIDFilter) > 0 {
+		// Add a filter condition if hostsFilter is provided
+		query += " AND id = ANY($2)"
+		rows, err = s.db.Query(query, tenantID, pq.Array(hostsIDFilter))
+	} else {
+		rows, err = s.db.Query(query, tenantID)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch hosts: %w", err)
 	}

--- a/pkg/storage/host.go
+++ b/pkg/storage/host.go
@@ -311,7 +311,7 @@ func (s *PostgreSQLStore) ExistAlias(alias string) (bool, error) {
 
 func (s *PostgreSQLStore) GetHostVulnerabilityTrends(
 	hostID int,
-	timePeriodFilter string,
+	timePeriodFilter domain.TimePeriodFilter,
 	severityFilters []string,
 ) ([]domain.ServiceTimePeriod, error) {
 	// This query is kind of complicated, but what it does is fill out time_periods and labels,
@@ -368,7 +368,7 @@ func (s *PostgreSQLStore) GetHostVulnerabilityTrends(
 		ORDER BY tp.ordering_period;
   `
 
-	trendQueryParams := []any{hostID, timePeriodFilter}
+	trendQueryParams := []any{hostID, timePeriodFilter.String()}
 	trendSeverityWhereClause, trendQueryParams := s.buildSeverityWhereClause(severityFilters, trendQueryParams)
 	forattedTrendQuery := fmt.Sprintf(baseTrendQuery, trendSeverityWhereClause)
 	slog.Debug("Executing Host Trend Query",

--- a/pkg/storage/host.go
+++ b/pkg/storage/host.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -306,4 +307,89 @@ func (s *PostgreSQLStore) ExistAlias(alias string) (bool, error) {
 		return false, fmt.Errorf("failed to verify existence: %w", err)
 	}
 	return exists, nil
+}
+
+func (s *PostgreSQLStore) GetHostVulnerabilityTrends(
+	hostID int,
+	timePeriodFilter string,
+	severityFilters []string,
+) ([]domain.ServiceTimePeriod, error) {
+	// This query is kind of complicated, but what it does is fill out time_periods and labels,
+	// even when there is no data for said time_period. E.g: we only have data
+	// for February, but we want to have the counts for other months to be 0 too.
+	baseTrendQuery := `
+  		WITH TimePeriods as (
+			SELECT
+				CASE
+					WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'FMMonth')
+					WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(date_series, 'Q')
+					WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+					ELSE 'Unknown Period'
+				END AS time_period_label,
+				CASE
+					WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'YYYY-MM')
+					WHEN $2 = 'Quarter' THEN TO_CHAR(date_series, 'YYYY-Q')
+					WHEN $2 = 'Semester' THEN CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+					ELSE '1'
+				END AS ordering_period
+			FROM generate_series(
+				DATE_TRUNC('year', CURRENT_DATE),
+				DATE_TRUNC('year', CURRENT_DATE) + INTERVAL '1 year' - INTERVAL '1 day',
+				CASE
+					WHEN $2 = 'Month' THEN INTERVAL '1 month'
+					WHEN $2 = 'Quarter' THEN INTERVAL '3 month'
+					WHEN $2 = 'Semester' THEN INTERVAL '6 month'
+					ELSE INTERVAL '1 month'
+				END
+			) AS date_series
+		),
+		VulnerabilityCounts AS (
+			SELECT
+				CASE
+					WHEN $2 = 'Month' THEN TO_CHAR(s.started_at, 'FMMonth')
+					WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(s.started_at, 'Q')
+					WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(s.started_at, 'MM')::integer <= 6 THEN '1' ELSE '2' END
+					ELSE 'Unknown Period'
+				END AS time_period_label,
+				COUNT(sv.id) AS vulnerability_count
+			FROM scan_vulnerabilities sv
+			INNER JOIN scans s ON sv.scan_id = s.id
+			WHERE s.host_id = $1 
+				AND EXTRACT(YEAR FROM s.started_at) = EXTRACT(YEAR FROM CURRENT_DATE)
+				-- Severity Filter Dynamic Condition goes here
+				%s
+			GROUP BY time_period_label
+		)
+		SELECT
+			tp.time_period_label AS time_period,
+			COALESCE(vc.vulnerability_count, 0) AS vulnerability_count
+		FROM TimePeriods tp
+		LEFT JOIN VulnerabilityCounts vc ON tp.time_period_label = vc.time_period_label
+		ORDER BY tp.ordering_period;
+  `
+
+	trendQueryParams := []any{hostID, timePeriodFilter}
+	trendSeverityWhereClause, trendQueryParams := s.buildSeverityWhereClause(severityFilters, trendQueryParams)
+	forattedTrendQuery := fmt.Sprintf(baseTrendQuery, trendSeverityWhereClause)
+	slog.Debug("Executing Host Trend Query",
+		slog.Any("query_params", trendQueryParams))
+
+	trendsRows, err := s.db.Query(forattedTrendQuery, trendQueryParams...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query vulnerability trends for host %d: %w", hostID, err)
+	}
+	defer trendsRows.Close()
+
+	var timePeriods []domain.ServiceTimePeriod
+	for trendsRows.Next() {
+		var timePeriodData domain.ServiceTimePeriod
+		if err := trendsRows.Scan(&timePeriodData.TimePeriod, &timePeriodData.VulnerabilityCount); err != nil {
+			return nil, fmt.Errorf("failed to scan into time period: %w", err)
+		}
+		timePeriods = append(timePeriods, timePeriodData)
+	}
+	if trendsRows.Err() != nil {
+		return nil, fmt.Errorf("failed to iterate trend rows: %w", err)
+	}
+	return timePeriods, nil
 }

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -938,7 +938,7 @@ func (s *PostgreSQLStore) GetLatestScanByHostID(hostID int, fromDate, toDate *ti
 	var scan domain.Scan
 	row := s.db.QueryRow(query, hostID, fromDate, toDate)
 	if err := scanIntoScan(row, &scan); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to scan into scan: %w", err)
@@ -975,7 +975,7 @@ func (s *PostgreSQLStore) GetScanBeforeLatestByHostID(hostID int, fromDate, toDa
 	var scan domain.Scan
 	row := s.db.QueryRow(query, hostID, fromDate, toDate)
 	if err := scanIntoScan(row, &scan); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to scan into scan: %w", err)

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -738,94 +738,32 @@ func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(
 	summaryData.CategoryData = categoryData
 
 	// 2. Fetch trend data
-	// This query is kind of complicated, but what it does is fill out time_periods and labels,
-	// even when there is no data for said time_period. E.g: we only have data
-	// for February, but we want to have the counts for other months to be 0 too.
-	baseTrendQuery := `
-  WITH TimePeriods as (
-  SELECT 
-        CASE 
-          WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'FMMonth')
-          WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(date_series, 'Q')
-          WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
-          ELSE 'Unknown Period'
-        END AS time_period_label,
-        CASE
-          WHEN $2 = 'Month' THEN TO_CHAR(date_series, 'YYYY-MM')
-          WHEN $2 = 'Quarter' THEN TO_CHAR(date_series, 'YYYY-Q')
-          WHEN $2 = 'Semester' THEN CASE WHEN TO_CHAR(date_series, 'MM')::integer <= 6 THEN '1' ELSE '2' END
-          ELSE '1'
-        END AS ordering_period
-      FROM generate_series(
-        DATE_TRUNC('year', CURRENT_DATE),
-        DATE_TRUNC('year', CURRENT_DATE) + INTERVAL '1 year' - INTERVAL '1 day',
-        CASE
-          WHEN $2 = 'Month' THEN INTERVAL '1 month'
-          WHEN $2 = 'Quarter' THEN INTERVAL '3 month'
-          WHEN $2 = 'Semester' THEN INTERVAL '6 month'
-          ELSE INTERVAL '1 month'
-        END
-      ) AS date_series
-  ),
-  VulnerabilityCounts AS (
-  SELECT
-          CASE
-              WHEN $2 = 'Month' THEN TO_CHAR(sv.created_at, 'FMMonth')
-              WHEN $2 = 'Quarter' THEN 'Q' || TO_CHAR(sv.created_at, 'Q')
-              WHEN $2 = 'Semester' THEN 'Semester ' || CASE WHEN TO_CHAR(sv.created_at, 'MM')::integer <= 6 THEN '1' ELSE '2' END
-              ELSE 'Unknown Period'
-          END AS time_period_label,
-          COUNT(sv.id) AS vulnerability_count
-      FROM scan_vulnerabilities sv
-      WHERE sv.scan_id = $1
-        AND EXTRACT(YEAR FROM sv.created_at) = EXTRACT(YEAR FROM CURRENT_DATE)
-          -- Severity Filter Dynamic Condition goes here
-          %s
-      GROUP BY time_period_label
-  )
-  SELECT 
-    tp.time_period_label AS time_period,
-    COALESCE(vc.vulnerability_count, 0) AS vulnerability_count
-  FROM TimePeriods tp
-  LEFT JOIN VulnerabilityCounts vc ON tp.time_period_label = vc.time_period_label
-  ORDER BY tp.ordering_period;
-`
-
-	trendQueryParams := []any{scanID, timePeriodFilter}
-	trendSeverityWhereClause, trendQueryParams := s.buildSeverityWhereClause(severityFilters, trendQueryParams)
-	formattedTrendQuery := fmt.Sprintf(baseTrendQuery, trendSeverityWhereClause)
-	slog.Debug("Executing Summary Query",
-		slog.Any("query_params", trendQueryParams))
-
-	trendsRows, err := s.db.Query(formattedTrendQuery, trendQueryParams...)
+	scan, err := s.GetScanByID(scanID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query vulnerability trends: %w", err)
+		return nil, fmt.Errorf("failed to get scan to retrieve host_id: %w", err)
 	}
-	defer trendsRows.Close()
+	if scan == nil {
+		return nil, fmt.Errorf("scan not found with id: %s", scanID)
+	}
+
+	timePeriods, err := s.GetHostVulnerabilityTrends(scan.HostID, timePeriodFilter, severityFilters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get host vulnerabilty trends: %w", err)
+	}
 
 	var vulnerabilityTrends domain.ServiceVulnerabilityTrends
-	var timePeriods []domain.ServiceTimePeriod
+	vulnerabilityTrends.TimePeriods = timePeriods
+
 	var totalVulnCountForAvg, periodCountForAvg float64
-	for trendsRows.Next() {
-		var timePeriodData domain.ServiceTimePeriod
-		if err := trendsRows.Scan(&timePeriodData.TimePeriod, &timePeriodData.VulnerabilityCount); err != nil {
-			return nil, fmt.Errorf("failed to scan into time period: %w", err)
-		}
-		timePeriods = append(timePeriods, timePeriodData)
-		totalVulnCountForAvg += float64(timePeriodData.VulnerabilityCount)
+	for _, periodData := range timePeriods {
+		totalVulnCountForAvg += float64(periodData.VulnerabilityCount)
 		periodCountForAvg++
 	}
-	if err := trendsRows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate trend rows: %w", err)
-	}
-
-	vulnerabilityTrends.TimePeriods = timePeriods
 	if periodCountForAvg > 0 {
 		vulnerabilityTrends.AverageVulnerabilityCount = totalVulnCountForAvg / periodCountForAvg
 	} else {
 		vulnerabilityTrends.AverageVulnerabilityCount = 0.0
 	}
-
 	summaryData.VulnerabilityTrends = vulnerabilityTrends
 
 	return &summaryData, nil

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -633,7 +633,7 @@ func (s *PostgreSQLStore) UpdateProtectionScore(scanID uuid.UUID, protectionScor
 
 func (s *PostgreSQLStore) GetScanVulnerabilitiesSummary(
 	scanID uuid.UUID,
-	timePeriodFilter string,
+	timePeriodFilter domain.TimePeriodFilter,
 	severityFilters []string,
 ) (*domain.ScanVulnerabilitySummaryData, error) {
 	var summaryData domain.ScanVulnerabilitySummaryData

--- a/pkg/storage/scan.go
+++ b/pkg/storage/scan.go
@@ -947,6 +947,43 @@ func (s *PostgreSQLStore) GetLatestScanByHostID(hostID int, fromDate, toDate *ti
 	return &scan, nil
 }
 
+func (s *PostgreSQLStore) GetScanBeforeLatestByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
+	query := `
+    SELECT
+      id,
+      tenant_id,
+      operator_id,
+      host_id,
+      started_at,
+      created_at,
+      updated_at,
+      ended_at,
+      status,
+      protection_score
+    FROM
+      scans
+    WHERE
+      host_id = $1
+      AND started_at >= COALESCE($2, '1900-01-01'::DATE)
+      AND started_at <= COALESCE($3, NOW())
+    ORDER BY
+      started_at DESC
+    LIMIT 1
+    OFFSET 1;
+  `
+
+	var scan domain.Scan
+	row := s.db.QueryRow(query, hostID, fromDate, toDate)
+	if err := scanIntoScan(row, &scan); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to scan into scan: %w", err)
+	}
+
+	return &scan, nil
+}
+
 func (s *PostgreSQLStore) GetOldestScanByHostID(hostID int, fromDate, toDate *time.Time) (*domain.Scan, error) {
 	query := `
     SELECT

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -320,3 +320,19 @@ func (s *PostgreSQLStore) GetVulnerabilityByID(vulnID int) (*domain.Vulnerabilit
 
 	return &vuln, nil
 }
+
+func (s *PostgreSQLStore) GetScanVulnerabilityCount(scanID uuid.UUID) (int, error) {
+	query := `
+    SELECT COUNT(id)
+    FROM scan_vulnerabilities
+    WHERE scan_id = $1
+  `
+
+	var vulnCount int
+	err := s.db.QueryRow(query, scanID).Scan(&vulnCount)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query row: %w", err)
+	}
+
+	return vulnCount, nil
+}


### PR DESCRIPTION
## Tenant Security Dashboard 🛠️

This PR introduces the **Tenant Security Dashboard**, providing a structured view of security data.

**Key Changes:**

*   **New Dashboard API Endpoint:**  Exposes `/api/dashboard` (GET) to retrieve tenant security dashboard data.
*   **Dashboard Data Aggregation:** Implements backend logic to aggregate data for:
    *   Overall Security Posture Score & Variation
    *   Vulnerability Heat Map (Host Alias vs. Severity Count)
    *   Vulnerability Trends (filterable by time period and severity)
    *   Last Scan Summary (Host Alias, Scan Date, Vulnerability Counts & Variation)
    *   Top Hosts by Vulnerability Count

**Key Components Implemented (TenantService):**

*   **⚙️ `GetTenantDashboardData`**: Orchestrates the retrieval and aggregation of all dashboard data points. Fetches overall security posture, heat map, vulnerability trends, last scan data, and hosts with the most vulnerabilities. Skips hosts without latest scans for heatmap and vulnerability count data to avoid misleading information.
*   **🗺️ `getHostLatestScanMap`**:  Helper function to build a map of `host.ID` to their `latestScan` for efficient data access in other methods.
*   **🛡️ `GetTenantSecurityPosture`**: Calculates the overall tenant security posture by averaging the `ProtectionScore` from the latest and previous scans of hosts. Computes the variation between current and previous scores.
*   **🔥 `getHostSeverityHeatMap`**: Generates data for the vulnerability heat map. Iterates through hosts and their latest scans to count severities, returning a list of `HostAliasSeverityCountPair`. Skips hosts without latest scans.
*   **📈 `GetHostsVulnerabilityTrends`**:  Aggregates vulnerability trends across hosts for a given time period and severity filters. Uses `storage.GetHostVulnerabilityTrends` to fetch individual host trends and aggregates them into `ServiceTimePeriod` structs.
*   **⏱️ `getLatestScanData`**:  Identifies the most recent scan across all hosts and retrieves relevant insights (`HostAlias`, `TotalVulnerabilities`, `TotalVulnerabilitiesVariation`, `SeverityCounts`, `ScanDate`) for the "Last Scan" section of the dashboard. Returns `nil` if no latest scan is found.
*   **🏆 `GetHostsSortedByMostVulnerabilities`**:  Retrieves and sorts hosts based on their vulnerability counts from their latest scans. Returns a list of `HostAliasVulnerabilityPair` sorted in descending order of `VulnerabilityCount`.

**Data Flow:**

The `GetTenantDashboardData` method acts as the main entry point, calling other methods to gather specific data points and then assembling them into the `TenantDashboardData` struct, which will be used by the API endpoint.

This PR lays the groundwork for the Tenant Security Dashboard by providing the necessary backend data retrieval and processing logic.  The API endpoint and frontend integration will be implemented in subsequent PRs.
