### PR TITLE
Bug/kt 429 update web socket cors check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,7 @@ func main() {
 	// Handlers - WS
 	wsConfig := &common.Config{
 		Upgrader: websocket.Upgrader{
+			CheckOrigin:     authService.VerifyCORSOrigin,
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ func main() {
 	// Handlers - WS
 	wsConfig := &common.Config{
 		Upgrader: websocket.Upgrader{
-			CheckOrigin:     authService.VerifyCORSOrigin,
+			CheckOrigin:     authService.CheckOriginAllowed,
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},

--- a/pkg/interfaces/auth.go
+++ b/pkg/interfaces/auth.go
@@ -18,6 +18,7 @@ type IAuthService interface {
 	VerifyEmail(verificationID, tenantID string) (*fusionauth.BaseHTTPResponse, error)
 	GenerateOTP() auth.OTP
 	VerifyOTP(otp string) bool
+	VerifyCORSOrigin(r *http.Request) bool
 }
 
 type IAuthHandlers interface {

--- a/pkg/interfaces/auth.go
+++ b/pkg/interfaces/auth.go
@@ -18,7 +18,7 @@ type IAuthService interface {
 	VerifyEmail(verificationID, tenantID string) (*fusionauth.BaseHTTPResponse, error)
 	GenerateOTP() auth.OTP
 	VerifyOTP(otp string) bool
-	VerifyCORSOrigin(r *http.Request) bool
+	CheckOriginAllowed(r *http.Request) bool
 }
 
 type IAuthHandlers interface {

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -494,3 +494,15 @@ func (s *AuthService) VerifyOTP(otp string) bool {
 	defer s.mu.Unlock()
 	return s.otps.VerifyOTP(otp)
 }
+
+func (s *AuthService) VerifyCORSOrigin(r *http.Request) bool {
+	allowedOrigins := s.cfg.GetAllowedOrigins()
+	origin := r.Header.Get("Origin")
+
+	for _, allowedOrigin := range allowedOrigins {
+		if origin == allowedOrigin {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -495,7 +495,7 @@ func (s *AuthService) VerifyOTP(otp string) bool {
 	return s.otps.VerifyOTP(otp)
 }
 
-func (s *AuthService) VerifyCORSOrigin(r *http.Request) bool {
+func (s *AuthService) CheckOriginAllowed(r *http.Request) bool {
 	allowedOrigins := s.cfg.GetAllowedOrigins()
 	origin := r.Header.Get("Origin")
 


### PR DESCRIPTION
This pull request introduces a new method to check if the origin of a WebSocket request is allowed, enhancing the security of WebSocket connections. The changes include updates to the `cmd/main.go`, `pkg/interfaces/auth.go`, and `pkg/services/auth.go` files.

Security improvements:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R91): Added the `CheckOrigin` function to the WebSocket upgrader configuration to validate the origin of incoming WebSocket requests.
* [`pkg/interfaces/auth.go`](diffhunk://#diff-062a2666aeb1427e6fa26e485d50797d7888bddb11ad0941cf626607103eda22R21): Introduced the `CheckOriginAllowed` method in the `IAuthService` interface to define the contract for origin validation.
* [`pkg/services/auth.go`](diffhunk://#diff-d3792076d44e66b06fa403ef4e2e911bf19f51e0ec3fdb9daa23716edf66f901R497-R508): Implemented the `CheckOriginAllowed` method in the `AuthService` struct to check if the request's origin is in the list of allowed origins.

---

## Important ⚠️

For WebSocket requests via postman, the "Origin" header must be set to a valid request origin. If this is not done, the developer will receive a **403 response.**