### PR TITLE
Task/kt 430 implement vulnerability filtering by client status

### DIFF
--- a/pkg/ws/report/reportutils/utils.go
+++ b/pkg/ws/report/reportutils/utils.go
@@ -236,3 +236,38 @@ func GetUniqueCVSSValuesPerType(vulns []*domain.Vulnerability) UniqueCVSSValuesB
 
 	return uniqueWeaknessCVSSValuesMap
 }
+
+// FilterVulnerabilitiesByStatus filters a slice of vulnerabilities based on a client's current status.
+//
+// It returns two slices:
+//   - solved: A slice containing vulnerabilities that would be considered solved
+//     if the provided status was applied. A vulnerability is considered solved if
+//     its WeaknessType exists in the status map and its BaseCVSSScore is strictly
+//     greater than the corresponding CVSS threshold.
+//   - notSolved: A slice containing vulnerabilities that would not be considered
+//     solved if the provided status were applied. This includes vulnerabilities
+//     where either:
+//   - Their WeaknessType exists in the status map and their BaseCVSS Score
+//     is less than or equal to the corresponding CVSS threshold.
+//   - Their WeaknessType does not exists as a key in the status map.
+func FilterVulnerabilitiesByStatus(vulns []*domain.Vulnerability, status map[string]float64) (
+	solved []*domain.Vulnerability,
+	notSolved []*domain.Vulnerability,
+) {
+	solved = make([]*domain.Vulnerability, 0)
+	notSolved = make([]*domain.Vulnerability, 0)
+
+	for _, vuln := range vulns {
+		if cvssThreshold, ok := status[vuln.Type]; ok {
+			if vuln.BaseCVSSScore > cvssThreshold {
+				solved = append(solved, vuln)
+			} else {
+				notSolved = append(notSolved, vuln)
+			}
+		} else {
+			notSolved = append(notSolved, vuln)
+		}
+	}
+
+	return solved, notSolved
+}

--- a/pkg/ws/report/reportutils/utils.go
+++ b/pkg/ws/report/reportutils/utils.go
@@ -242,14 +242,14 @@ func GetUniqueCVSSValuesPerType(vulns []*domain.Vulnerability) UniqueCVSSValuesB
 // It returns two slices:
 //   - solved: A slice containing vulnerabilities that would be considered solved
 //     if the provided status was applied. A vulnerability is considered solved if
-//     its WeaknessType exists in the status map and its BaseCVSSScore is strictly
+//     its Type exists in the status map and its BaseCVSSScore is strictly
 //     greater than the corresponding CVSS threshold.
 //   - notSolved: A slice containing vulnerabilities that would not be considered
 //     solved if the provided status were applied. This includes vulnerabilities
 //     where either:
 //   - Their WeaknessType exists in the status map and their BaseCVSS Score
 //     is less than or equal to the corresponding CVSS threshold.
-//   - Their WeaknessType does not exists as a key in the status map.
+//   - Their WeaknessType does not exist as a key in the status map.
 func FilterVulnerabilitiesByStatus(vulns []*domain.Vulnerability, status map[string]float64) (
 	solved []*domain.Vulnerability,
 	notSolved []*domain.Vulnerability,

--- a/pkg/ws/report/reportutils/utils_test.go
+++ b/pkg/ws/report/reportutils/utils_test.go
@@ -206,3 +206,92 @@ func TestGetUniqueCVSSValuesPerType(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterVulnerabilitiesByStatus(t *testing.T) {
+	testCases := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		vulns         []*domain.Vulnerability
+		status        map[string]float64
+		wantSolved    []*domain.Vulnerability
+		wantNotSolved []*domain.Vulnerability
+	}{
+		{
+			name:          "Empty vulnerability slice",
+			vulns:         []*domain.Vulnerability{},
+			status:        map[string]float64{},
+			wantSolved:    []*domain.Vulnerability{},
+			wantNotSolved: []*domain.Vulnerability{},
+		},
+		{
+			name: "Vulnerability slice with empty status",
+			vulns: []*domain.Vulnerability{
+				{Type: "SSRF"},
+				{Type: "Injection"},
+			},
+			status:     map[string]float64{},
+			wantSolved: []*domain.Vulnerability{},
+			wantNotSolved: []*domain.Vulnerability{
+				{Type: "SSRF"},
+				{Type: "Injection"},
+			},
+		},
+		{
+			name: "Vulnerability slice with non-empty status",
+			vulns: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			status: map[string]float64{
+				"SSRF":      6.5,
+				"Injection": 4.0,
+			},
+			wantSolved: []*domain.Vulnerability{
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			wantNotSolved: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+			},
+		},
+		{
+			name: "Vulnerability slice with status equal to the CVSS",
+			vulns: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			status: map[string]float64{
+				"SSRF":      5.0,
+				"Injection": 5.0,
+			},
+			wantSolved: []*domain.Vulnerability{},
+			wantNotSolved: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+		},
+		{
+			name: "Status with 0.0 Desired CVSS",
+			vulns: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			status: map[string]float64{
+				"SSRF":      0.0,
+				"Injection": 0.0,
+			},
+			wantSolved: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			wantNotSolved: []*domain.Vulnerability{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSolved, gotNotSolved := reportutils.FilterVulnerabilitiesByStatus(tc.vulns, tc.status)
+
+			assert.Equal(t, gotSolved, tc.wantSolved, "FilterVulnerabilitiesByStatus() = %v, want %v", gotSolved, tc.wantSolved)
+			assert.Equal(t, gotNotSolved, tc.wantNotSolved, "FilterVulnerabilitiesByStatus() = %v, want %v", gotNotSolved, tc.wantNotSolved)
+		})
+	}
+}

--- a/pkg/ws/report/reportutils/utils_test.go
+++ b/pkg/ws/report/reportutils/utils_test.go
@@ -285,6 +285,25 @@ func TestFilterVulnerabilitiesByStatus(t *testing.T) {
 			},
 			wantNotSolved: []*domain.Vulnerability{},
 		},
+		{
+			name: "Vulnerability with Type not included in map",
+			vulns: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+				{Type: "Another WeaknessType", BaseCVSSScore: 5.0},
+			},
+			status: map[string]float64{
+				"SSRF":      0.0,
+				"Injection": 0.0,
+			},
+			wantSolved: []*domain.Vulnerability{
+				{Type: "SSRF", BaseCVSSScore: 5.0},
+				{Type: "Injection", BaseCVSSScore: 5.0},
+			},
+			wantNotSolved: []*domain.Vulnerability{
+				{Type: "Another WeaknessType", BaseCVSSScore: 5.0},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new function to filter vulnerabilities based on their status, along with corresponding unit tests to ensure its correctness. The most important changes include the addition of the `FilterVulnerabilitiesByStatus` function and the creation of test cases for this function.

### New Functionality:

* [`pkg/ws/report/reportutils/utils.go`](diffhunk://#diff-7a3a4fa7403a99265f53fedfa61f4dbb6df6388be2febbebcd97669de32b4ec7R239-R273): Added the `FilterVulnerabilitiesByStatus` function, which filters a slice of vulnerabilities into solved and not solved based on a given status map.

### Unit Tests:

* [`pkg/ws/report/reportutils/utils_test.go`](diffhunk://#diff-94930558c07aaf9d384823db2b5a3cebb2d4ca10bcb0ac4ecbe593352666c1b9R209-R297): Added the `TestFilterVulnerabilitiesByStatus` function with multiple test cases to validate the behavior of the `FilterVulnerabilitiesByStatus` function.