### PR TITLE
fix(websocket): Add message type to server response messages

### DIFF
--- a/pkg/ws/common/message.go
+++ b/pkg/ws/common/message.go
@@ -1,6 +1,11 @@
 package common
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kptm-tools/core-service/pkg/ws/report/dto"
+)
 
 // Message represents the DTO struct being sent over WebSocket
 // Used to differ between different actions
@@ -9,4 +14,18 @@ type Message struct {
 	Type string `json:"type"`
 	// Payload is the data Based on the Type
 	Payload json.RawMessage `json:"payload"`
+}
+
+func BuildServerMessageBytes(messageType dto.ServerMessageType, payload json.RawMessage) ([]byte, error) {
+	msg := Message{
+		Type:    messageType.String(),
+		Payload: payload,
+	}
+
+	msgBytes, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal websocket message: %w", err)
+	}
+
+	return msgBytes, nil
 }

--- a/pkg/ws/report/dto/dto.go
+++ b/pkg/ws/report/dto/dto.go
@@ -4,6 +4,32 @@ import (
 	"github.com/kptm-tools/core-service/pkg/domain"
 )
 
+type ClientMessageType string
+
+const (
+	MessageInitialRequest ClientMessageType = "initial_data_request"
+	MessageVectorUpdate   ClientMessageType = "vector_update"
+	MessageSelectVector   ClientMessageType = "select_vector"
+	MessageApplyVectors   ClientMessageType = "apply_vectors_request"
+)
+
+func (s ClientMessageType) String() string {
+	return string(s)
+}
+
+type ServerMessageType string
+
+const (
+	MessageInitialDataResponse   ServerMessageType = "initial_data_response"
+	MessageVectorUpdateResponse  ServerMessageType = "vector_update_response"
+	MessageVectorDetailsResponse ServerMessageType = "vector_details_response"
+	MessageReportDataResponse    ServerMessageType = "report_data_response"
+)
+
+func (s ServerMessageType) String() string {
+	return string(s)
+}
+
 // InitialDataRequest is the payload send in a MessageInitialRequest (Client -> Server)
 type InitialDataRequest struct {
 	ScanID string `json:"scan_id"`

--- a/pkg/ws/report/handlers/apply_vectors.go
+++ b/pkg/ws/report/handlers/apply_vectors.go
@@ -2,16 +2,15 @@ package wshandlers
 
 import (
 	"encoding/json"
+	"log/slog"
+
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/ws/report/dto"
 	"github.com/kptm-tools/core-service/pkg/ws/report/reportutils"
-	"log/slog"
 
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 	"github.com/kptm-tools/core-service/pkg/ws/common"
 )
-
-const MessageApplyVectors = "apply_vectors_request"
 
 type ApplyVectorsHandler struct{}
 
@@ -27,18 +26,24 @@ func (h *ApplyVectorsHandler) Handle(msg common.Message, client interfaces.IRepo
 		return customerrors.NewServerSideError("Client has not joined room")
 	}
 	solved, notSolved := reportutils.FilterVulnerabilitiesByStatus(client.GetHubReport().GetRoomVulnerabilities(roomID), client.GetVectorStatus())
-	reportResponse := dto.ReportDetailsResponse{
+	payload := dto.ReportDetailsResponse{
 		SolvedVulnerabilities:     solved,
 		UnattendedVulnerabilities: notSolved,
 		ExpectedSecurityPosture:   reportutils.GetGlobalCVSSScore(notSolved),
 	}
-	responseBytes, err := json.Marshal(reportResponse)
+	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		slog.Error("Failed to marshal vector update response", slog.Any("error", err))
 		return customerrors.NewServerSideError("failed to marshal vector update response")
 	}
 
+	msgBytes, err := common.BuildServerMessageBytes(dto.MessageReportDataResponse, payloadBytes)
+	if err != nil {
+		slog.Error("Failed to marshal message", slog.Any("error", err))
+		return customerrors.NewServerSideError("failed to marshal message")
+	}
+
 	slog.Debug("Sending back response...")
-	client.GetSend() <- responseBytes
+	client.GetSend() <- msgBytes
 	return nil
 }

--- a/pkg/ws/report/handlers/apply_vectors.go
+++ b/pkg/ws/report/handlers/apply_vectors.go
@@ -33,7 +33,7 @@ func (h *ApplyVectorsHandler) Handle(msg common.Message, client interfaces.IRepo
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		slog.Error("Failed to marshal vector update response", slog.Any("error", err))
+		slog.Error("Failed to marshal report data response", slog.Any("error", err))
 		return customerrors.NewServerSideError("failed to marshal vector update response")
 	}
 

--- a/pkg/ws/report/handlers/initial_request.go
+++ b/pkg/ws/report/handlers/initial_request.go
@@ -12,10 +12,6 @@ import (
 	"github.com/kptm-tools/core-service/pkg/ws/report/reportutils"
 )
 
-const (
-	MessageInitialRequest = "initial_data_request"
-)
-
 type InitialRequestHandler struct {
 	scanService interfaces.IScanService
 }
@@ -47,14 +43,20 @@ func (h *InitialRequestHandler) Handle(msg common.Message, client interfaces.IRe
 		return customerrors.NewServerSideError("failed to get vulnerabilities for scan")
 	}
 
-	response := reportutils.BuildVulnerabilityTypeData(vulns)
-	responseBytes, err := json.Marshal(response)
+	payload := reportutils.BuildVulnerabilityTypeData(vulns)
+	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		slog.Error("Failed to marshal initial data response", slog.Any("error", err))
 		return customerrors.NewServerSideError("failed to marshal initial data response")
 	}
 
+	msgBytes, err := common.BuildServerMessageBytes(dto.MessageInitialDataResponse, payloadBytes)
+	if err != nil {
+		slog.Error("Failed to marshal message", slog.Any("error", err))
+		return customerrors.NewServerSideError("failed to marshal message")
+	}
+
 	client.SetVectorStatus(reportutils.GetMaxCVSSPerType(vulns))
-	client.GetSend() <- responseBytes
+	client.GetSend() <- msgBytes
 	return nil
 }

--- a/pkg/ws/report/handlers/select_vector.go
+++ b/pkg/ws/report/handlers/select_vector.go
@@ -12,8 +12,6 @@ import (
 	"github.com/kptm-tools/core-service/pkg/ws/report/reportutils"
 )
 
-const MessageSelectVector = "select_vector"
-
 type SelectVectorHandler struct{}
 
 func NewSelectVectorHandler() *SelectVectorHandler {
@@ -55,17 +53,23 @@ func (h *SelectVectorHandler) Handle(msg common.Message, client interfaces.IRepo
 		return customerrors.NewServerSideError("Could not find highest CVSS vulnerability of type")
 	}
 
-	// 4. If all is right, build the response
-	response := dto.VectorDetailsResponse{
+	// 4. If all is right, build the payload
+	payload := dto.VectorDetailsResponse{
 		VulnerabilityDetails: dto.NewVulnerabilityDetails(*highestVuln),
 	}
-	responseBytes, err := json.Marshal(response)
+	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		slog.Error("Failed to marshal vector details response", slog.Any("error", err))
 		return customerrors.NewServerSideError("Failed to marshal vector details response")
 	}
 
+	msgBytes, err := common.BuildServerMessageBytes(dto.MessageVectorDetailsResponse, payloadBytes)
+	if err != nil {
+		slog.Error("Failed to marshal message", slog.Any("error", err))
+		return customerrors.NewServerSideError("failed to marshal message")
+	}
+
 	slog.Debug("Sending back response...")
-	client.GetSend() <- responseBytes
+	client.GetSend() <- msgBytes
 	return nil
 }

--- a/pkg/ws/report/handlers/vector_update.go
+++ b/pkg/ws/report/handlers/vector_update.go
@@ -3,17 +3,16 @@ package wshandlers
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
+
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/ws/report/dto"
 	"github.com/kptm-tools/core-service/pkg/ws/report/reportutils"
-	"log/slog"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 	"github.com/kptm-tools/core-service/pkg/ws/common"
 )
-
-const MessageVectorUpdate = "vector_update"
 
 type VectorUpdateHandler struct{}
 
@@ -45,13 +44,19 @@ func (h *VectorUpdateHandler) Handle(msg common.Message, client interfaces.IRepo
 		ExpectedGlobalCVSSScore:            reportutils.GetGlobalCVSSScore(notSolved),
 		ExpectedGlobalTotalVulnerabilities: reportutils.GetGlobalTotalVulnerabilities(notSolved),
 	}
-	responseBytes, err := json.Marshal(vectorUpdateResponse)
+	payloadBytes, err := json.Marshal(vectorUpdateResponse)
 	if err != nil {
 		slog.Error("Failed to marshal vector update response", slog.Any("error", err))
 		return customerrors.NewServerSideError("failed to marshal vector update response")
 	}
 
+	msgBytes, err := common.BuildServerMessageBytes(dto.MessageVectorUpdateResponse, payloadBytes)
+	if err != nil {
+		slog.Error("Failed to marshal message", slog.Any("error", err))
+		return customerrors.NewServerSideError("failed to marshal message")
+	}
+
 	slog.Debug("Sending back response...")
-	client.GetSend() <- responseBytes
+	client.GetSend() <- msgBytes
 	return nil
 }

--- a/pkg/ws/report/hub.go
+++ b/pkg/ws/report/hub.go
@@ -1,16 +1,18 @@
 package report
 
 import (
-	"github.com/google/uuid"
-	"github.com/kptm-tools/core-service/pkg/domain"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/kptm-tools/core-service/pkg/domain"
+
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 	"github.com/kptm-tools/core-service/pkg/ws/common"
+	"github.com/kptm-tools/core-service/pkg/ws/report/dto"
 	wshandlers "github.com/kptm-tools/core-service/pkg/ws/report/handlers"
 	"github.com/kptm-tools/core-service/pkg/ws/utils"
 )
@@ -38,10 +40,10 @@ func NewReportHub(
 	authService interfaces.IAuthService,
 ) *ReportHub {
 	handlers := map[string]interfaces.IReportHandler{
-		wshandlers.MessageInitialRequest: wshandlers.NewInitialRequestHandler(scanService),
-		wshandlers.MessageVectorUpdate:   wshandlers.NewVectorUpdateHandler(),
-		wshandlers.MessageSelectVector:   wshandlers.NewSelectVectorHandler(),
-		wshandlers.MessageApplyVectors:   wshandlers.NewApplyVectorsHandler(),
+		dto.MessageInitialRequest.String(): wshandlers.NewInitialRequestHandler(scanService),
+		dto.MessageVectorUpdate.String():   wshandlers.NewVectorUpdateHandler(),
+		dto.MessageSelectVector.String():   wshandlers.NewSelectVectorHandler(),
+		dto.MessageApplyVectors.String():   wshandlers.NewApplyVectorsHandler(),
 	}
 
 	return &ReportHub{
@@ -160,7 +162,6 @@ func (h *ReportHub) AddToRoom(scanID string) {
 		slog.Info("Increasing the amount of clients for scanID", slog.String("scan_id", scanID))
 	}
 	slog.Info("Client joined room", slog.String("scan_id", scanID))
-
 }
 
 func (h *ReportHub) RemoveFromRoom(scanID string) {


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of WebSocket messages in the core-service package. The most important changes include the addition of new message types, the creation of a utility function for building server messages, and refactoring handlers to utilize this new function.

### Addition of new message types:

* [`pkg/ws/report/dto/dto.go`](diffhunk://#diff-9668b131c6b45556d789fcee1da0f631d18a2c5ee17eeecab6f814cc044d9e30R7-R32): Added `ClientMessageType` and `ServerMessageType` enums to define various client and server message types.

### Utility function for building server messages:

* [`pkg/ws/common/message.go`](diffhunk://#diff-7f1e5d038294e34f50891dd8eb4145dd99cb481a253e7c40ff42ac07156c5bccR18-R31): Introduced `BuildServerMessageBytes` function to construct and marshal WebSocket messages, improving consistency and reducing code duplication.

### Refactoring handlers to use the new utility function:

* [`pkg/ws/report/handlers/apply_vectors.go`](diffhunk://#diff-240523c7d6abd576045340174c6cd104aa96f8b835833a67f2dca1b5d316d929L30-R47): Updated the `ApplyVectorsHandler` to use `BuildServerMessageBytes` for constructing response messages.
* [`pkg/ws/report/handlers/initial_request.go`](diffhunk://#diff-73853290fc0cbf822f00d9b14948bd78ea998937e5b04848f21fbf6f9d7c3b11L50-R60): Modified the `InitialRequestHandler` to use `BuildServerMessageBytes` for building initial data response messages.
* [`pkg/ws/report/handlers/select_vector.go`](diffhunk://#diff-53463e996663202169f71e60d85a570a60cd292f1cd99c36931d427e7ffde183L58-R73): Refactored the `SelectVectorHandler` to utilize `BuildServerMessageBytes` for creating vector details response messages.
* [`pkg/ws/report/handlers/vector_update.go`](diffhunk://#diff-f07173f5a445f6087f891a345ec8bba91f12153fdcf1d3376b10487794b2bf95L48-R60): Updated the `VectorUpdateHandler` to use `BuildServerMessageBytes` for constructing vector update response messages.

### Miscellaneous improvements:

* [`pkg/ws/report/hub.go`](diffhunk://#diff-835ffa0c6ca47a483933a227e2af3e488ce948c15e262a9d8c5a0869b3568d39L41-R46): Refactored the `NewReportHub` function to use the new message type enums for handler mapping.