### PR TITLE
Task/kt 435 build data structure for vulnerability solutions list

### DIFF
--- a/pkg/ws/report/dto/dto.go
+++ b/pkg/ws/report/dto/dto.go
@@ -122,7 +122,7 @@ type GraphData struct {
 type Series struct {
 	Name    string      `json:"name"`
 	Data    []DataPoint `json:"data"`
-	Average float64     `json:"value,omitempty"` // Optional field for static value (e.g: average)
+	Average float64     `json:"average,omitempty"` // Optional field for static value (e.g: average)
 }
 
 type DataPoint struct {

--- a/pkg/ws/report/dto/dto.go
+++ b/pkg/ws/report/dto/dto.go
@@ -112,4 +112,20 @@ type ReportDetailsResponse struct {
 	SolvedVulnerabilities     []*domain.Vulnerability `json:"solved_vulnerabilities"`
 	UnattendedVulnerabilities []*domain.Vulnerability `json:"unattended_vulnerabilities"`
 	ExpectedSecurityPosture   float64                 `json:"expected_security_posture"`
+	GraphData                 GraphData               `json:"vulnerability_graph"`
+}
+
+type GraphData struct {
+	Series []Series `json:"series"` // Represents each different line in the chart that must be plotted
+}
+
+type Series struct {
+	Name    string      `json:"name"`
+	Data    []DataPoint `json:"data"`
+	Average float64     `json:"value,omitempty"` // Optional field for static value (e.g: average)
+}
+
+type DataPoint struct {
+	X string  `json:"x"`
+	Y float64 `json:"y"`
 }

--- a/pkg/ws/report/handlers/apply_vectors.go
+++ b/pkg/ws/report/handlers/apply_vectors.go
@@ -25,11 +25,16 @@ func (h *ApplyVectorsHandler) Handle(msg common.Message, client interfaces.IRepo
 	if roomID == "" {
 		return customerrors.NewServerSideError("Client has not joined room")
 	}
-	solved, notSolved := reportutils.FilterVulnerabilitiesByStatus(client.GetHubReport().GetRoomVulnerabilities(roomID), client.GetVectorStatus())
+
+	scanVulns := client.GetHubReport().GetRoomVulnerabilities(roomID)
+	clientStatus := client.GetVectorStatus()
+
+	solved, notSolved := reportutils.FilterVulnerabilitiesByStatus(scanVulns, clientStatus)
 	payload := dto.ReportDetailsResponse{
 		SolvedVulnerabilities:     solved,
 		UnattendedVulnerabilities: notSolved,
 		ExpectedSecurityPosture:   reportutils.GetGlobalCVSSScore(notSolved),
+		GraphData:                 reportutils.BuildVulnerabilityGraph(scanVulns, notSolved),
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/ws/report/reportutils/utils.go
+++ b/pkg/ws/report/reportutils/utils.go
@@ -301,3 +301,74 @@ func GetHighestCVSSVulnerabilityOfType(vulns []*domain.Vulnerability, vulnType e
 
 	return highestVuln
 }
+
+// GetUniqueVulnTypes returns a slice with unique Weakness Types found within a vulnerability slice.
+func GetUniqueVulnTypes(vulns []*domain.Vulnerability) []enums.WeaknessType {
+	uniqueTypes := make([]enums.WeaknessType, 0)
+	for _, vuln := range vulns {
+		wt, ok := enums.ParseWeaknessFromString(vuln.Type)
+		if !ok {
+			slog.Warn("Found an invalid vulnerability type when building vulnerability graph",
+				slog.Int("vuln_id", vuln.ID),
+				slog.String("vuln_type", vuln.Type))
+			continue
+		}
+		if !contains(uniqueTypes, wt) {
+			uniqueTypes = append(uniqueTypes, wt)
+		}
+	}
+
+	return uniqueTypes
+}
+
+func BuildVulnerabilityGraph(vulns []*domain.Vulnerability, notSolvedVulns []*domain.Vulnerability) dto.GraphData {
+	actualDataPoints := make([]dto.DataPoint, 0)
+
+	expectedDataPoints := make([]dto.DataPoint, 0)
+
+	// 1. Get each unique type within vulners (X values)
+	uniqueTypes := GetUniqueVulnTypes(vulns)
+
+	for _, wt := range uniqueTypes {
+		actualDataPoints = append(actualDataPoints, dto.DataPoint{
+			X: wt.String(),
+			Y: GetHighestCVSSVulnerabilityOfType(vulns, wt).BaseCVSSScore,
+		})
+		expectedDataPoints = append(expectedDataPoints, dto.DataPoint{
+			X: wt.String(),
+			Y: GetHighestCVSSVulnerabilityOfType(notSolvedVulns, wt).BaseCVSSScore,
+		})
+	}
+
+	actualAvg := calculateSeriesAvg(actualDataPoints)
+	expectedAvg := calculateSeriesAvg(expectedDataPoints)
+
+	return dto.GraphData{
+		Series: []dto.Series{
+			{Name: "Actual", Data: actualDataPoints, Average: actualAvg},
+			{Name: "Expected", Data: expectedDataPoints, Average: expectedAvg},
+		},
+	}
+}
+
+func calculateSeriesAvg(dataPoints []dto.DataPoint) float64 {
+	avg := 0.0
+	sum := 0.0
+
+	for _, dataPoint := range dataPoints {
+		sum += dataPoint.Y
+	}
+	if len(dataPoints) != 0 {
+		avg = sum / float64(len(dataPoints))
+	}
+	return avg
+}
+
+func contains[T comparable](slice []T, value T) bool {
+	for _, item := range slice {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ws/report/reportutils/utils.go
+++ b/pkg/ws/report/reportutils/utils.go
@@ -330,13 +330,23 @@ func BuildVulnerabilityGraph(vulns []*domain.Vulnerability, notSolvedVulns []*do
 	uniqueTypes := GetUniqueVulnTypes(vulns)
 
 	for _, wt := range uniqueTypes {
+		actualHighestCVSS := 0.0
+		expectedHighestCVSS := 0.0
+
+		if highestActualVuln := GetHighestCVSSVulnerabilityOfType(vulns, wt); highestActualVuln != nil {
+			actualHighestCVSS = highestActualVuln.BaseCVSSScore
+		}
+		if highestExpectedVuln := GetHighestCVSSVulnerabilityOfType(notSolvedVulns, wt); highestExpectedVuln != nil {
+			expectedHighestCVSS = highestExpectedVuln.BaseCVSSScore
+		}
+
 		actualDataPoints = append(actualDataPoints, dto.DataPoint{
 			X: wt.String(),
-			Y: GetHighestCVSSVulnerabilityOfType(vulns, wt).BaseCVSSScore,
+			Y: actualHighestCVSS,
 		})
 		expectedDataPoints = append(expectedDataPoints, dto.DataPoint{
 			X: wt.String(),
-			Y: GetHighestCVSSVulnerabilityOfType(notSolvedVulns, wt).BaseCVSSScore,
+			Y: expectedHighestCVSS,
 		})
 	}
 

--- a/pkg/ws/report/reportutils/utils_test.go
+++ b/pkg/ws/report/reportutils/utils_test.go
@@ -420,3 +420,50 @@ func TestGetHighestCVSSVulnerabilityOfType(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUniqueVulnTypes(t *testing.T) {
+	testCases := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		vulns []*domain.Vulnerability
+		want  []enums.WeaknessType
+	}{
+		{
+			name: "Slice with one vulnerability type",
+			vulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String()},
+			},
+			want: []enums.WeaknessType{enums.WeaknessInjection},
+		},
+		{
+			name:  "Empty vulnerability slice",
+			vulns: []*domain.Vulnerability{},
+			want:  []enums.WeaknessType{},
+		},
+		{
+			name: "Slice with two vulnerabilities with the same type",
+			vulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String()},
+				{Type: enums.WeaknessInjection.String()},
+			},
+			want: []enums.WeaknessType{enums.WeaknessInjection},
+		},
+		{
+			name: "Slice with two vulnerabilities with a different type",
+			vulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String()},
+				{Type: enums.WeaknessSSRF.String()},
+			},
+			want: []enums.WeaknessType{
+				enums.WeaknessInjection, enums.WeaknessSSRF,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reportutils.GetUniqueVulnTypes(tc.vulns)
+
+			assert.Equal(t, tc.want, got, "Expected weakness type slice %v, got %v", tc.want, got)
+		})
+	}
+}

--- a/pkg/ws/report/reportutils/utils_test.go
+++ b/pkg/ws/report/reportutils/utils_test.go
@@ -458,12 +458,89 @@ func TestGetUniqueVulnTypes(t *testing.T) {
 				enums.WeaknessInjection, enums.WeaknessSSRF,
 			},
 		},
+		{
+			name: "Slice with invalid weakness",
+			vulns: []*domain.Vulnerability{
+				{Type: "Invalid weakness"},
+			},
+			want: []enums.WeaknessType{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := reportutils.GetUniqueVulnTypes(tc.vulns)
 
 			assert.Equal(t, tc.want, got, "Expected weakness type slice %v, got %v", tc.want, got)
+		})
+	}
+}
+
+func TestBuildVulnerabilityGraph(t *testing.T) {
+	testCases := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		vulns          []*domain.Vulnerability
+		notSolvedVulns []*domain.Vulnerability
+		want           dto.GraphData
+	}{
+		{
+			name: "One unsolved vuln",
+			vulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String(), BaseCVSSScore: 6.6},
+			},
+			notSolvedVulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String(), BaseCVSSScore: 6.6},
+			},
+			want: dto.GraphData{
+				Series: []dto.Series{
+					{Name: "Actual", Data: []dto.DataPoint{{X: enums.WeaknessInjection.String(), Y: 6.6}}, Average: 6.6},
+					{Name: "Expected", Data: []dto.DataPoint{{X: enums.WeaknessInjection.String(), Y: 6.6}}, Average: 6.6},
+				},
+			},
+		},
+		{
+			name:           "Empty vulns",
+			vulns:          []*domain.Vulnerability{},
+			notSolvedVulns: []*domain.Vulnerability{},
+			want: dto.GraphData{
+				Series: []dto.Series{
+					{Name: "Actual", Data: []dto.DataPoint{}, Average: 0.0},
+					{Name: "Expected", Data: []dto.DataPoint{}, Average: 0.0},
+				},
+			},
+		},
+		{
+			name: "No unsolved vulns",
+			vulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String(), BaseCVSSScore: 6.6},
+			},
+			notSolvedVulns: []*domain.Vulnerability{},
+			want: dto.GraphData{
+				Series: []dto.Series{
+					{Name: "Actual", Data: []dto.DataPoint{{X: enums.WeaknessInjection.String(), Y: 6.6}}, Average: 6.6},
+					{Name: "Expected", Data: []dto.DataPoint{{X: enums.WeaknessInjection.String(), Y: 0.0}}, Average: 0.0},
+				},
+			},
+		},
+		{
+			name:  "No vulns but one unsolved vuln",
+			vulns: []*domain.Vulnerability{},
+			notSolvedVulns: []*domain.Vulnerability{
+				{Type: enums.WeaknessInjection.String(), BaseCVSSScore: 6.6},
+			},
+			want: dto.GraphData{
+				Series: []dto.Series{
+					{Name: "Actual", Data: []dto.DataPoint{}, Average: 0.0},
+					{Name: "Expected", Data: []dto.DataPoint{}, Average: 0.0},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reportutils.BuildVulnerabilityGraph(tc.vulns, tc.notSolvedVulns)
+
+			assert.Equal(t, tc.want, got, "Expected GraphData %v, got %v", tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces significant changes to the vulnerability reporting feature by adding a new graph data structure and associated utility functions. These changes enhance the capability to visualize vulnerability data in a graphical format.

Enhancements to vulnerability reporting:

* [`pkg/ws/report/dto/dto.go`](diffhunk://#diff-9668b131c6b45556d789fcee1da0f631d18a2c5ee17eeecab6f814cc044d9e30R115-R130): Added a new `GraphData` structure to the `ReportDetailsResponse` struct, which includes `Series` and `DataPoint` types for plotting vulnerability data.

Utility function additions:

* [`pkg/ws/report/reportutils/utils.go`](diffhunk://#diff-7a3a4fa7403a99265f53fedfa61f4dbb6df6388be2febbebcd97669de32b4ec7R304-R384): Introduced the `BuildVulnerabilityGraph` function to create graph data from vulnerabilities and the `GetUniqueVulnTypes` function to extract unique vulnerability types.
* [`pkg/ws/report/handlers/apply_vectors.go`](diffhunk://#diff-240523c7d6abd576045340174c6cd104aa96f8b835833a67f2dca1b5d316d929L28-R37): Updated the `Handle` method to include the new `GraphData` in the `ReportDetailsResponse` payload.

Testing improvements:

* [`pkg/ws/report/reportutils/utils_test.go`](diffhunk://#diff-94930558c07aaf9d384823db2b5a3cebb2d4ca10bcb0ac4ecbe593352666c1b9R423-R546): Added tests for the new `GetUniqueVulnTypes` and `BuildVulnerabilityGraph` functions to ensure they work as expected.