### PR TITLE
fix(ReportDetailsResponse): Standardize security posture float64 between 0 and 1

### DIFF
--- a/pkg/ws/report/handlers/apply_vectors.go
+++ b/pkg/ws/report/handlers/apply_vectors.go
@@ -33,7 +33,7 @@ func (h *ApplyVectorsHandler) Handle(msg common.Message, client interfaces.IRepo
 	payload := dto.ReportDetailsResponse{
 		SolvedVulnerabilities:     solved,
 		UnattendedVulnerabilities: notSolved,
-		ExpectedSecurityPosture:   reportutils.GetGlobalCVSSScore(notSolved),
+		ExpectedSecurityPosture:   reportutils.GetGlobalCVSSScore(notSolved) / 10,
 		GraphData:                 reportutils.BuildVulnerabilityGraph(scanVulns, notSolved),
 	}
 	payloadBytes, err := json.Marshal(payload)


### PR DESCRIPTION
This pull request includes a minor adjustment to the `pkg/ws/report/handlers/apply_vectors.go` file. The change modifies the calculation of the `ExpectedSecurityPosture` in the `Handle` method of the `ApplyVectorsHandler` to divide the result of `reportutils.GetGlobalCVSSScore(notSolved)` by 10.

* [`pkg/ws/report/handlers/apply_vectors.go`](diffhunk://#diff-240523c7d6abd576045340174c6cd104aa96f8b835833a67f2dca1b5d316d929L36-R36): Adjusted the `ExpectedSecurityPosture` calculation to divide the score by 10.