### PR TITLE
feat(ScanFailedEvent): Initialize handler and subscribe to event subject

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -16,6 +16,8 @@ func SetupEventBus(eventBus cmmn.EventBus, scanService interfaces.IScanService) 
 
 	nmapHandler := consumers.NewNmapHandler(scanService)
 
+	scanFailedHandler := consumers.NewScanFailedHandler(scanService)
+
 	err := eventBus.Subscribe(string(enums.DNSLookupEventSubject), dnsLookupHandler.HandleMessage)
 	if err != nil {
 		return err
@@ -30,6 +32,10 @@ func SetupEventBus(eventBus cmmn.EventBus, scanService interfaces.IScanService) 
 	}
 
 	if err := eventBus.Subscribe(string(enums.NmapEventSubject), nmapHandler.HandleMessage); err != nil {
+		return err
+	}
+
+	if err := eventBus.Subscribe(string(enums.ScanFailedEventSubject), scanFailedHandler.HandleMessage); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This pull request updates the `SetupEventBus` function in `pkg/events/events.go` to handle a new event type, improving the system's ability to process failure scenarios. The logic for handling a `ScanFailedEvent` had been implemented, but not integrated! 😂