### PR TITLE
Add type field to ScanVulnerabilityItem

### DIFF
--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -123,6 +123,7 @@ type ScanVulnerabilityItemsResponse struct {
 type ScanVulnerabilityItem struct {
 	ID             int                   `json:"id"`
 	Name           string                `json:"name"`
+	Type           string                `json:"type"`
 	Severity       string                `json:"severity"`
 	MaxCVSS        float64               `json:"max_cvss"`
 	RiskScore      float64               `json:"risk_score"`
@@ -360,6 +361,7 @@ func ToScanVulnerabilityItem(vuln *domain.Vulnerability) ScanVulnerabilityItem {
 	return ScanVulnerabilityItem{
 		ID:             vuln.ID,
 		Name:           vuln.VulnerabilityID,
+		Type:           vuln.Type,
 		Severity:       vuln.BaseSeverity.String(),
 		MaxCVSS:        vuln.BaseCVSSScore,
 		RiskScore:      vuln.RiskScore,


### PR DESCRIPTION
This pull request introduces a new `Type` field to the `ScanVulnerabilityItem` struct in `pkg/dto/response.go` and updates the corresponding transformation function to populate this field. These changes enhance the struct's ability to represent vulnerability data more comprehensively, and allow the final Dynamic Report Frontend view to filter vulnerabilities properly by type.

### Enhancements to `ScanVulnerabilityItem` struct:

* Added a new `Type` field of type `string` to the `ScanVulnerabilityItem` struct, allowing it to capture the type of vulnerability. (`pkg/dto/response.go`, [pkg/dto/response.goR126](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cR126))

### Updates to transformation logic:

* Updated the `ToScanVulnerabilityItem` function to map the `Type` field from the `domain.Vulnerability` object to the newly added `Type` field in `ScanVulnerabilityItem`. (`pkg/dto/response.go`)