### PR TITLE
Task/kt 460 add git hub actions workflow for go audit checks

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,40 @@
+name: Go Audit Checks
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs: 
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.8'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with: 
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download Go modules (for application & audit tools)
+        run: go mod download
+
+      - name: Install audit tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run audit checks
+        run: make audit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5
+FROM golang:1.23.8
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kptm-tools/core-service
 
-go 1.23.5
-
-toolchain go1.24.2
+go 1.23.8
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.2


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for auditing Go code and updates the Go version used across the project to ensure compatibility and security. The most important changes include adding the `Go Audit Checks` workflow, updating the Go version in the `Dockerfile`, and aligning the Go version in the `go.mod` file.

### New GitHub Actions Workflow:
* [`.github/workflows/audit.yml`](diffhunk://#diff-93a89f16f6717d1e4e4e27ec20ef916e3355c7aa890ca74cd9b12db30d8a899fR1-R40): Added a `Go Audit Checks` workflow to run static analysis and vulnerability checks on pull requests targeting the `dev` branch. This includes setting up Go, caching modules, installing audit tools (`staticcheck` and `govulncheck`), and executing `make audit`.

### Go Version Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Updated the base Go image from `1.23.5` to `1.23.8` to use the latest patch version for improved stability and security.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the `go` directive from `1.23.5` to `1.23.8` to align with the updated Go version used in the project. Removed the `toolchain` directive for Go `1.24.2`.