### PR TITLE
feat: schema for web vulnerability

### DIFF
--- a/db/sql/migrations/000024_create_web_vulnerabilities_table.down.sql
+++ b/db/sql/migrations/000024_create_web_vulnerabilities_table.down.sql
@@ -1,0 +1,2 @@
+-- Migration: 000024_create_web_vulnerabilities_table.down.sql
+DROP TABLE IF EXISTS web_vulnerabilities;

--- a/db/sql/migrations/000024_create_web_vulnerabilities_table.up.sql
+++ b/db/sql/migrations/000024_create_web_vulnerabilities_table.up.sql
@@ -1,0 +1,17 @@
+-- Migration: 000024_create_web_vulnerabilities_table.up.sql
+CREATE TABLE IF NOT EXISTS web_vulnerabilities (
+    vulnerability_id UUID PRIMARY KEY,
+    scan_id UUID NOT NULL, -- The specific scan run that found this instance
+    host_id UUID NOT NULL, -- The specific host this instance was found on
+    service_id INTEGER, -- The specific service this instance is related to
+    solution_advice text,
+    reference varchar(255),
+    other_info text,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_web_vulns_vulnerability_id FOREIGN KEY (vulnerability_id) REFERENCES vulnerabilities (id) ON DELETE CASCADE,
+    CONSTRAINT fk_web_vulns_scan_id FOREIGN KEY (scan_id) REFERENCES scans (id) ON DELETE CASCADE,
+    CONSTRAINT fk_web_vulns_host_id FOREIGN KEY (host_id) REFERENCES hosts (id) ON DELETE CASCADE,
+    CONSTRAINT fk_web_vulns_service_id FOREIGN KEY (service_id) REFERENCES services (id) ON DELETE SET NULL
+);

--- a/db/sql/migrations/000025_create_web_vulnerability_details_table.down.sql
+++ b/db/sql/migrations/000025_create_web_vulnerability_details_table.down.sql
@@ -1,0 +1,2 @@
+-- Migration: 000025_create_web_vulnerability_details_table.down.sql
+DROP TABLE IF EXISTS web_vxulnerability_details;

--- a/db/sql/migrations/000025_create_web_vulnerability_details_table.up.sql
+++ b/db/sql/migrations/000025_create_web_vulnerability_details_table.up.sql
@@ -1,0 +1,12 @@
+-- Migration: 000025_create_web_vulnerability_details_table.up.sql
+CREATE TABLE IF NOT EXISTS web_vulnerability_details (
+    id UUID PRIMARY KEY,
+    vulnerability_id UUID NOT NULL,
+    uri TEXT,
+    method TEXT,
+    param TEXT,
+    attack TEXT,
+    evidence TEXT,
+    other_info TEXT,
+    CONSTRAINT fk_web_vulns_detail_vulnerability_id FOREIGN KEY (vulnerability_id) REFERENCES web_vulnerabilities (vulnerability_id) ON DELETE CASCADE
+);

--- a/db/sql/migrations/000026_add_wasc_in_vulnerabilities_table.down.sql
+++ b/db/sql/migrations/000026_add_wasc_in_vulnerabilities_table.down.sql
@@ -1,0 +1,8 @@
+-- Migration: 000026_create_web_vulnerability_details_table.down.sql
+ALTER TABLE vulnerabilities
+DROP CONSTRAINT IF EXISTS fk_vulnerabilities_wasc_details;
+
+ALTER TABLE vulnerabilities
+DROP COLUMN IF EXISTS wasc_id;
+
+DROP TABLE IF EXISTS wasc_details;

--- a/db/sql/migrations/000026_add_wasc_in_vulnerabilities_table.up.sql
+++ b/db/sql/migrations/000026_add_wasc_in_vulnerabilities_table.up.sql
@@ -1,0 +1,18 @@
+-- Migration: 000026_wasc_in_vulnerabilities_table.up.sql
+CREATE TABLE IF NOT EXISTS wasc_details (
+    wasc_id VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    last_updated TIMESTAMP WITH TIME ZONE NOT NULL
+                               );
+
+ALTER TABLE vulnerabilities
+    ADD COLUMN wasc_id VARCHAR(255);
+
+ALTER TABLE vulnerabilities
+    ADD CONSTRAINT fk_vulnerabilities_wasc_details
+        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
+            ON DELETE SET NULL
+            ON UPDATE CASCADE;
+
+CREATE INDEX idx_vulnerabilities_wasc_id ON vulnerabilities (wasc_id);


### PR DESCRIPTION
For instances alert I have consider another table for storing it. It will be better for showing users what pages they should review to leverage those observations.

Consider that we have this answer in the struct parse  

```json
{
  "site": [
    {
      "alerts": [
        {
          "pluginid": "40012",
          "alertRef": "40012",
          "alert": "Cross Site Scripting (Reflected)",
          "name": "Cross Site Scripting (Reflected)",
          "riskcode": "3",
          "confidence": "2",
          "riskdesc": "High (Medium)",
          "desc": "Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user's browser instance.",
          "instances": [
            {
              "id": "2237",
              "uri": "http://testfire.net/search.jsp?query=%3C%2Fp%3E%3CscrIpt%3Ealert%281%29%3B%3C%2FscRipt%3E%3Cp%3E",
              "method": "GET",
              "param": "query",
              "attack": "<script>alert(1);</script>",
              "evidence": "<script>alert(1);</script>",
              "other_info": ""
            }
          ],
          "count": "1",
          "solution": "Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.",
          "other_info": "",
          "reference": "https://owasp.org/www-community/attacks/xss/",
          "cweid": "79",
          "wascid": "8",
          "sourceid": "3291"
        },
        {
          "pluginid": "40018",
          "alertRef": "40018",
          "alert": "SQL Injection",
          "name": "SQL Injection",
          "riskcode": "3",
          "confidence": "2",
          "riskdesc": "High (Medium)",
          "desc": "SQL injection may be possible.",
          "instances": [
            {
              "id": "4236",
              "uri": "http://testfire.net/default.jsp?content=security.htm%27+AND+%271%27%3D%271%27+--+",
              "method": "GET",
              "param": "content",
              "attack": "security.htm' AND '1'='1' -- ",
              "evidence": "",
              "other_info": ""
            }
          ],
          "count": "1",
          "solution": "Do not trust client side input, even if there is client side validation in place.",
          "other_info": "",
          "reference": "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
          "cweid": "89",
          "wascid": "19",
          "sourceid": "23190"
        }
      ]
    }
  ]
}
```
We assume that in cwe_details exists a record with 89.
This will map to the following  inserts
First there is not any wasc insert it like this
```sql
INSERT INTO wasc_details (
    wasc_id,
    title,
    description,
    last_updated
) VALUES
             ('01', 'SQL Injection', 'Injection flaws, such as SQL, occur when untrusted data is sent to an interpreter as part of a command or query.', '2025-06-26T10:15:00+00:00'),
             ('08', 'Cross Site Scripting', 'XSS flaws occur whenever an application includes untrusted data in a new web page without proper validation or escaping.', '2025-06-25T14:30:00+00:00'),
             ('19', 'Buffer Overflow', 'Buffer overflow vulnerabilities occur when a program writes more data to a buffer than it can hold.', '2025-06-20T09:00:00+00:00');
```
Then insert into  vulnerabilities
```sql
INSERT INTO vulnerabilities (
    id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, cwe_id, wasc_id
) VALUES
('00000000-0000-0000-0000-000000000001', 'ea0ce497-6ecc-4663-80e2-c23bd6584b74', '1128049c-a3e4-4ed0-ab6e-1f719b57821f', NULL,
 'Cross Site Scripting (DOM Based)',
 'Cross-site Scripting (XSS) is an attack technique that involves echoing attacker-supplied code into a user browser instance. ',
 'High', 'OWASP ZAP', 'WEB_APPLICATION', NULL, 'CWE-89', '19');
INSERT INTO vulnerabilities (
    id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, cwe_id, wasc_id
) VALUES
('00000000-0000-0000-0000-000000000002', 'ea0ce497-6ecc-4663-80e2-c23bd6584b74', '1128049c-a3e4-4ed0-ab6e-1f719b57821f', NULL,
 'SQL Injection',
 'SQL injection may be possible.',
 'High', 'OWASP ZAP', 'WEB_APPLICATION', NULL, 'CWE-22', '08');
```
Then we need to create a service, each web scan will have by default one service that will the http
```sql
INSERT INTO services (
    host_id,
    scan_id,
    port,
    protocol,
    sv_name,
    sv_version,
    confidence,
    cpe,
    product,
    port_state,
    created_at,
    updated_at
) VALUES (
    'ea0ce497-6ecc-4663-80e2-c23bd6584b74',
    '1128049c-a3e4-4ed0-ab6e-1f719b57821f',
    80,
    'tcp',
    'http',
    '',
    100,
    '',
    'Apache httpd',
    'open',
    '2025-06-26 12:36:33.745107',
    '2025-06-26 12:36:33.745107'
);
```
Then we insert in web_vulnerabilities
```sql
INSERT INTO web_vulnerabilities (
    vulnerability_id,
    scan_id,
    host_id,
    service_id,
    solution_advice,
    reference,
    other_info,
    created_at,
    updated_at
) VALUES (
    '00000000-0000-0000-0000-000000000001', -- one of the ids that we insert previously
    '1128049c-a3e4-4ed0-ab6e-1f719b57821f', -- scan_id (must exist in scans)
    'ea0ce497-6ecc-4663-80e2-c23bd6584b74', -- host_id (must exist in hosts)
    69,                                       -- this is the result from last insertion of service
    'Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.',
    'https://owasp.org/www-community/attacks/xss/',
    '', current_date, current_date);

INSERT INTO web_vulnerabilities (
    vulnerability_id,
    scan_id,
    host_id,
    service_id,
    solution_advice,
    reference,
    other_info,
    created_at,
    updated_at
) VALUES (
    '00000000-0000-0000-0000-000000000002', -- one of the ids that we insert previously
    '1128049c-a3e4-4ed0-ab6e-1f719b57821f', -- scan_id (must exist in scans)
    'ea0ce497-6ecc-4663-80e2-c23bd6584b74', -- host_id (must exist in hosts)
    69,                                       -- this is the result from last insertion of service
    'Do not trust client side input, even if there is client side validation in place.',
    'https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html',
    '', current_date, current_date);

INSERT INTO web_vulnerability_details (
    id,
    vulnerability_id,
    uri,
    method,
    param,
    attack,
    evidence,
    other_info
) VALUES (
    '00000001-0000-0000-0000-000000000001',
    '00000000-0000-0000-0000-000000000001',
    'http://testfire.net/search.jsp?query=%3C%2Fp%3E%3CscrIpt%3Ealert%281%29%3B%3C%2FscRipt%3E%3Cp%3E',
    'GET',
    'query',
    '<script>alert(1);</script>',
    '<script>alert(1);</script>',
    ''
);

INSERT INTO web_vulnerability_details (
    id,
    vulnerability_id,
    uri,
    method,
    param,
    attack,
    evidence,
    other_info
) VALUES (
    '00000001-0000-0000-0000-000000000002',
    '00000000-0000-0000-0000-000000000002',
    'http://testfire.net/default.jsp?content=security.htm%27+AND+%271%27%3D%271%27+--+',
    'GET',
    'content',
    'security.htm'' AND ''1''=''1'' -- ',
    '',
    ''
);
```