### PR TITLE
fix: Improve date format in DTO response for ScanDate and VulnDate

### DIFF
--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -225,8 +225,8 @@ type ScoreCardTrendResponse struct {
 // ScanVulnerabilityDetailResponse is the DTO with the details for a particular
 // scan's vulenrability.
 type ScanVulnerabilityDetailResponse struct {
-	ID       string    `json:"id"`
-	ScanDate time.Time `json:"scan_date"`
+	ID       string `json:"id"`
+	ScanDate string `json:"scan_date"`
 
 	Host HostItem  `json:"host"`
 	Port *PortItem `json:"port,omitempty"`
@@ -303,8 +303,8 @@ type OSItem struct {
 }
 
 type DateInfo struct {
-	Published   time.Time `json:"published"`
-	LastUpdated time.Time `json:"last_updated"`
+	Published   string `json:"published"`
+	LastUpdated string `json:"last_updated"`
 }
 
 // PluginInfo refers to info about the service/operating system
@@ -380,8 +380,8 @@ func AdaptDomainOSItem(domainOSItem *domain.OSItem) *OSItem {
 
 func AdaptDomainDateInfo(domainDateInfo domain.DateInfo) DateInfo {
 	return DateInfo{
-		Published:   domainDateInfo.Published,
-		LastUpdated: domainDateInfo.LastUpdated,
+		Published:   domainDateInfo.Published.Format(time.DateOnly),
+		LastUpdated: domainDateInfo.LastUpdated.Format(time.DateOnly),
 	}
 }
 

--- a/pkg/handlers/vulnerability.go
+++ b/pkg/handlers/vulnerability.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/kptm-tools/core-service/pkg/api"
 	"github.com/kptm-tools/core-service/pkg/customerrors"
@@ -51,8 +52,7 @@ func (h *VulnerabilityHandlers) GetVulnerability(w http.ResponseWriter, r *http.
 
 	vulnDetailResponse := dto.ScanVulnerabilityDetailResponse{
 		ID:       vulnDetail.ID.String(),
-		ScanDate: vulnDetail.ScanDate,
-
+		ScanDate: vulnDetail.ScanDate.Format(time.DateTime),
 		Host: dto.HostItem{
 			Alias:     vulnDetail.Host.Alias,
 			IPAddress: vulnDetail.Host.IPAddress,


### PR DESCRIPTION
This pull request updates how date and time values are handled in the codebase, transitioning from `time.Time` types to formatted string representations. The changes ensure consistency in date formatting across different parts of the application. Additionally, a minor import adjustment was made to include the `time` package in a relevant file.

### Transition to formatted date strings:

* [`pkg/dto/response.go`](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL229-R229): Updated the `ScanDate`, `Published`, and `LastUpdated` fields in `ScanVulnerabilityDetailResponse` and `DateInfo` structs to use string types instead of `time.Time`. [[1]](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL229-R229) [[2]](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL306-R307)
* [`pkg/dto/response.go`](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL383-R384): Modified the `AdaptDomainDateInfo` function to format `Published` and `LastUpdated` fields as strings using `time.DateOnly`.

### Adjustments in handlers:

* [`pkg/handlers/vulnerability.go`](diffhunk://#diff-483cafe8571e1c61e56ca6516208359cb3cf65f9a69e56261c485d67101315e5L54-R55): Updated the `ScanDate` field in the `GetVulnerability` handler to format the date using `time.DateTime`.