### PR TITLE
KT-522: Refactor Event Consumer Handlers for Improved Testability

### DIFF
--- a/pkg/events/consumers/dnslookup.go
+++ b/pkg/events/consumers/dnslookup.go
@@ -3,7 +3,10 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"runtime/debug"
+	"time"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/events"
@@ -23,54 +26,75 @@ func NewDNSLookupHandler(scanService interfaces.IScanService) *DNSLookupHandler 
 var _ interfaces.EventConsumer = (*DNSLookupHandler)(nil)
 
 func (h *DNSLookupHandler) HandleMessage(msg *nats.Msg) {
-	go func(msg *nats.Msg) {
-		ctx := context.Background()
-		slog.Info("Received DNSLookupEvent")
-
-		// 1. Parse payload
-		var evt events.ToolResultEvent
-		if err := json.Unmarshal(msg.Data, &evt); err != nil {
-			slog.Error("Failed to unmarshal ToolResultEvent", slog.Any("error", err))
-			return
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic recovered in DNSLookupHandler", "panic", r, "stack", string(debug.Stack()))
 		}
+	}()
+	slog.Info("Received DNSLookupEvent")
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Second)
+	defer cancel()
+	go h.processDNSLookupEventRoutine(ctx, msg.Data)
+	<-ctx.Done()
+}
 
-		// 2. Validate contents
-		if evt.ToolResult.Tool != enums.ToolDNSLookup {
-			slog.Error("Invalid toolName for DNSLookupEvent", slog.String("tool_name", string(evt.ToolResult.Tool)))
-			return
+func (h *DNSLookupHandler) processDNSLookupEventRoutine(ctx context.Context, data []byte) {
+	select {
+	case <-ctx.Done():
+		slog.Debug("DNSLookupHandler context cancelled or timed out", slog.Any("error", ctx.Err()))
+	default:
+		err := h.processDNSLookupEvent(ctx, data)
+		if err != nil {
+			slog.Debug("Error processing DNSLookupEvent", "error", err)
 		}
+	}
+}
 
-		// 2.1 Check if the current scan status is still healthy
-		scan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
-		if errScan != nil {
-			slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
-			return
-		}
+func (h *DNSLookupHandler) processDNSLookupEvent(ctx context.Context, data []byte) error {
+	// 1. Parse payload
+	var evt events.ToolResultEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		slog.Error("Failed to unmarshal ToolResultEvent", slog.Any("error", err))
+		return err
+	}
 
-		if scan.IsFailedOrCancelled() {
-			slog.Error("Error inserting ScanResult to DB because of Scan Status",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("current_status ", scan.Status),
-			)
-			return
-		}
+	// 2. Validate contents
+	if evt.ToolResult.Tool != enums.ToolDNSLookup {
+		slog.Error("Invalid toolName for DNSLookupEvent", slog.String("tool_name", string(evt.ToolResult.Tool)))
+		return errors.New("invalid toolName for DNSLookupEvent")
+	}
 
-		// 2.2 Check for errors in the result
-		handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
+	// 2.1 Check if the current scan status is still healthy
+	scan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
+	if errScan != nil {
+		slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
+		return errScan
+	}
 
-		// 3. Save ToolResult to DB
-		scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
+	if scan.IsFailedOrCancelled() {
+		slog.Error("Error inserting ScanResult to DB because of Scan Status",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("current_status ", scan.Status),
+		)
+		return errors.New("error inserting ScanResult to DB of Scan Status")
+	}
 
-		if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
-			slog.Error("Error inserting ScanResult to DB",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("error", err),
-			)
-			return
-		}
+	// 2.2 Check for errors in the result
+	handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
 
-		slog.Debug("DNSLookupEvent handled successfully")
-	}(msg)
+	// 3. Save ToolResult to DB
+	scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
+
+	if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
+		slog.Error("Error inserting ScanResult to DB",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("error", err),
+		)
+		return err
+	}
+
+	slog.Debug("DNSLookupEvent handled successfully")
+	return nil
 }

--- a/pkg/events/consumers/dnslookup.go
+++ b/pkg/events/consumers/dnslookup.go
@@ -77,7 +77,7 @@ func (h *DNSLookupHandler) processDNSLookupEvent(ctx context.Context, data []byt
 			slog.String("tool_name", string(evt.ToolResult.Tool)),
 			slog.Any("current_status ", scan.Status),
 		)
-		return errors.New("error inserting ScanResult to DB of Scan Status")
+		return errors.New("cannot insert scan result: scan is failed or cancelled")
 	}
 
 	// 2.2 Check for errors in the result

--- a/pkg/events/consumers/dnslookup_test.go
+++ b/pkg/events/consumers/dnslookup_test.go
@@ -1,0 +1,202 @@
+package consumers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+	mock_services "github.com/kptm-tools/core-service/pkg/mocks/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessDNSLookupEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		scanService   interfaces.IScanService
+		data          []byte
+		expectedError string
+	}{
+		{
+			name:          "Invalid JSON",
+			scanService:   &mock_services.MockScanService{},
+			data:          []byte(``),
+			expectedError: "unexpected end of JSON input",
+		},
+		{
+			name:          "Invalid tool name",
+			scanService:   &mock_services.MockScanService{},
+			data:          []byte(`{}`),
+			expectedError: "invalid toolName for DNSLookupEvent",
+		},
+		{
+			name: "Scan not found",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return nil, customerrors.ErrScanNotFound
+				},
+			},
+			data: []byte(`{
+				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
+				"ToolResult": {
+					"tool_name": "DNSLookup",
+					"result": null
+				}
+			}`),
+			expectedError: "scan not found",
+		},
+		{
+			name: "Scan is failed or cancelled",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{
+						ID:     id,
+						Status: "Failed",
+					}, nil
+				},
+			},
+			data: []byte(`{
+				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
+				"ToolResult": {
+					"tool_name": "DNSLookup",
+					"result": null
+				}
+			}`),
+			expectedError: "error inserting ScanResult to DB of Scan Status",
+		},
+		{
+			name: "Error in inserting scan result",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "InProgress"}, nil
+				},
+				MockInsertScanResult: func(ctx context.Context, result domain.ScanResult) error {
+					return errors.New("error in inserting scan result")
+				},
+			},
+			data: []byte(`{
+				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
+				"ToolResult": {
+					"tool_name": "DNSLookup",
+					"result": null,
+					"timestamp": "2025-07-07T12:34:56Z"
+				}
+			}`),
+			expectedError: "error in inserting scan result",
+		},
+		{
+			name: "Good insertion",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{
+						ID:     id,
+						Status: "InProgress",
+					}, nil
+				},
+				MockInsertScanResult: func(ctx context.Context, sr domain.ScanResult) error {
+					return nil
+				},
+			},
+			data: []byte(`{
+				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
+				"ToolResult": {
+					"tool_name": "DNSLookup",
+					"result": {
+					  "domain": "testfire.net",
+					  "dns_records": [
+						{
+						  "type": "A",
+						  "name": "testfire.net.",
+						  "ttl": 21600,
+						  "value": "65.61.137.117"
+						}
+					  ],
+					  "dnssec_enabled": false,
+					  "lookup_duration": 1496295752,
+					  "created_at": "2025-07-31T17:34:39.109806531Z",
+					  "timestamp": "2025-07-31T17:34:37.613510237Z",
+					  "whois_results": {
+						"tool_name": "WhoIs",
+						"result": {
+						  "raw_data": {
+							"domain": {
+							  "id": "8363973_DOMAIN_NET-VRSN",
+							  "domain": "testfire.net",
+							  "punycode": "testfire.net",
+							  "name": "testfire",
+							  "extension": "net",
+							  "whois_server": "whois.registrar.amazon",
+							  "status": [
+								"clientDeleteProhibited",
+								"clientTransferProhibited",
+								"clientUpdateProhibited"
+							  ],
+							  "name_servers": [
+								"asia3.akam.net"
+							  ],
+							  "created_date": "1999-07-23T13:52:32Z",
+							  "updated_date": "2025-02-27T17:53:33Z",
+							  "expiration_date": "2026-07-23T13:52:32Z"
+							},
+							"registrar": {
+							  "id": "468",
+							  "name": "Amazon Registrar, Inc.",
+							  "phone": "+1.2024422253",
+							  "email": "trustandsafety@support.aws.com",
+							  "referral_url": "https://registrar.amazon.com"
+							},
+							"registrant": {
+							  "id": "Not Available From Registry",
+							  "name": "On behalf of testfire.net owner",
+							  "organization": "Identity Protection Service",
+							  "street": "PO Box 786",
+							  "city": "Hayes",
+							  "province": "Middlesex",
+							  "postal_code": "UB3 9TR",
+							  "country": "GB",
+							  "phone": "+44.1483307527",
+							  "fax": "+44.1483304031",
+							  "email": "ff33a434-8474-412e-b6f2-2e6b503c99fb@identity-protect.org"
+							},
+							"technical": {
+							  "id": "Not Available From Registry",
+							  "name": "On behalf of testfire.net owner",
+							  "organization": "Identity Protection Service",
+							  "street": "PO Box 786",
+							  "city": "Hayes",
+							  "province": "Middlesex",
+							  "postal_code": "UB3 9TR",
+							  "country": "GB",
+							  "phone": "+44.1483307527",
+							  "fax": "+44.1483304031",
+							  "email": "ff33a434-8474-412e-b6f2-2e6b503c99fb@identity-protect.org"
+							}
+						  }
+						}
+					  }
+					}
+				}
+			}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewDNSLookupHandler(tt.scanService)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := h.processDNSLookupEvent(ctx, tt.data)
+
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/events/consumers/dnslookup_test.go
+++ b/pkg/events/consumers/dnslookup_test.go
@@ -66,7 +66,7 @@ func TestProcessDNSLookupEvent(t *testing.T) {
 					"result": null
 				}
 			}`),
-			expectedError: "error inserting ScanResult to DB of Scan Status",
+			expectedError: "cannot insert scan result: scan is failed or cancelled",
 		},
 		{
 			name: "Error in inserting scan result",

--- a/pkg/events/consumers/harvester.go
+++ b/pkg/events/consumers/harvester.go
@@ -90,7 +90,7 @@ func (h *HarvesterHandler) processHarvesterEvent(ctx context.Context, data []byt
 	// 3. Save ToolResult to DB
 	scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
 	if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
-		slog.Error("Error inserting Scanresult to DB",
+		slog.Error("Error inserting ScanResult to DB",
 			slog.String("scan_id", evt.ScanID.String()),
 			slog.String("tool_name", string(evt.ToolResult.Tool)),
 			slog.Any("error", err))

--- a/pkg/events/consumers/harvester.go
+++ b/pkg/events/consumers/harvester.go
@@ -3,7 +3,10 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"runtime/debug"
+	"time"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/events"
@@ -23,53 +26,77 @@ func NewHarvesterHandler(scanService interfaces.IScanService) *HarvesterHandler 
 var _ interfaces.EventConsumer = (*HarvesterHandler)(nil)
 
 func (h *HarvesterHandler) HandleMessage(msg *nats.Msg) {
-	go func(msg *nats.Msg) {
-		ctx := context.Background()
-		slog.Info("Received HarvesterEvent")
-
-		// 1. Parse payload
-		var evt events.ToolResultEvent
-		if err := json.Unmarshal(msg.Data, &evt); err != nil {
-			slog.Error("Failed to unmarshal ToolResultEvent",
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("error", err))
-			return
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic recovered in HarvesterHandler", "panic", r, "stack", string(debug.Stack()))
 		}
+	}()
+	slog.Info("Received HarvesterEvent")
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Second)
+	defer cancel()
+	go h.processHarvesterEventRoutine(ctx, msg.Data)
+	<-ctx.Done()
+}
 
-		// 2. Validate contents
-		if evt.ToolResult.Tool != enums.ToolHarvester {
-			slog.Error("Invalid toolName for HarvesterEvent", slog.String("tool_name", string(evt.ToolResult.Tool)))
-			return
+func (h *HarvesterHandler) processHarvesterEventRoutine(ctx context.Context, data []byte) {
+	select {
+	case <-ctx.Done():
+		slog.Debug("HarvesterHandler context cancelled or timed out", slog.Any("error", ctx.Err()))
+	default:
+		err := h.processHarvesterEvent(ctx, data)
+		if err != nil {
+			slog.Debug("Error processing HarvesterEvent", "error", err)
 		}
+	}
+}
 
-		// 2.1 Check if the current scan status is still healthy
-		scan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
-		if errScan != nil {
-			slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
-			return
-		}
-		if scan.IsFailedOrCancelled() {
-			slog.Error("Error inserting ScanResult to DB because of Scan Status",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("current_status ", scan.Status),
-			)
-			return
-		}
+func (h *HarvesterHandler) processHarvesterEvent(ctx context.Context, data []byte) error {
 
-		// 2.2 Check for errors in the result
-		handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
+	// 1. Parse payload
+	var evt events.ToolResultEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		slog.Error("Failed to unmarshal ToolResultEvent",
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("error", err))
+		return err
+	}
 
-		// 3. Save ToolResult to DB
-		scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
-		if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
-			slog.Error("Error inserting Scanresult to DB",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("error", err))
-			return
-		}
+	// 2. Validate contents
+	if evt.ToolResult.Tool != enums.ToolHarvester {
+		slog.Error("Invalid toolName for HarvesterEvent",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)))
+		return errors.New("invalid toolName for HarvesterEvent")
+	}
 
-		slog.Debug("HarvesterEvent handled successfully")
-	}(msg)
+	// 2.1 Check if the current scan status is still healthy
+	scan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
+	if errScan != nil {
+		slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
+		return errScan
+	}
+	if scan.IsFailedOrCancelled() {
+		slog.Error("Error inserting ScanResult to DB because of Scan Status",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("current_status ", scan.Status),
+		)
+		return errors.New("error inserting ScanResult to DB of Scan Status")
+	}
+
+	// 2.2 Check for errors in the result
+	handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
+
+	// 3. Save ToolResult to DB
+	scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
+	if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
+		slog.Error("Error inserting Scanresult to DB",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("error", err))
+		return err
+	}
+
+	slog.Debug("HarvesterEvent handled successfully")
+	return nil
 }

--- a/pkg/events/consumers/harvester.go
+++ b/pkg/events/consumers/harvester.go
@@ -81,7 +81,7 @@ func (h *HarvesterHandler) processHarvesterEvent(ctx context.Context, data []byt
 			slog.String("tool_name", string(evt.ToolResult.Tool)),
 			slog.Any("current_status ", scan.Status),
 		)
-		return errors.New("error inserting ScanResult to DB of Scan Status")
+		return errors.New("cannot insert scan result: scan is failed or cancelled")
 	}
 
 	// 2.2 Check for errors in the result

--- a/pkg/events/consumers/harvester_test.go
+++ b/pkg/events/consumers/harvester_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProcessWhoIsEvent(t *testing.T) {
+func TestProcessHarvesterEvent(t *testing.T) {
 
 	tests := []struct {
 		name          string
@@ -32,7 +32,7 @@ func TestProcessWhoIsEvent(t *testing.T) {
 			name:          "Invalid tool name",
 			scanService:   &mock_services.MockScanService{},
 			data:          []byte(`{}`),
-			expectedError: "invalid toolName for WhoIsEvent",
+			expectedError: "invalid toolName for HarvesterEvent",
 		},
 		{
 			name: "Scan not found",
@@ -42,13 +42,12 @@ func TestProcessWhoIsEvent(t *testing.T) {
 				},
 			},
 			data: []byte(`{
-							  "scan_id": "123e4567-e89b-12d3-a456-426614174000",
-							  "timestamp": "2025-07-07T12:34:56Z",
-                              "ToolResult": {"tool_name": "WhoIs",
-                              "result": null,
-							  "error": null,
-							  "timestamp": "2025-07-07T12:34:56Z"
-							}}`),
+				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
+				"ToolResult": {
+					"tool_name": "Harvester",
+					"result": null
+				}
+			}`),
 			expectedError: "scan not found",
 		},
 		{
@@ -64,7 +63,7 @@ func TestProcessWhoIsEvent(t *testing.T) {
 			data: []byte(`{
 				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
 				"ToolResult": {
-					"tool_name": "WhoIs",
+					"tool_name": "Harvester",
 					"result": null,
 					"timestamp": "2025-07-07T12:34:56Z"
 				}
@@ -87,32 +86,10 @@ func TestProcessWhoIsEvent(t *testing.T) {
 			data: []byte(`{
 				"scan_id": "dfa86ed2-5601-4dec-be89-97a16a579dfb",
 				"ToolResult": {
-					"tool_name": "WhoIs",
+					"tool_name": "Harvester",
 					"result": {
-					  "raw_data": {
-						"domain": {
-						  "id": "8363973_DOMAIN_NET-VRSN",
-						  "domain": "testfire.net",
-						  "punycode": "testfire.net",
-						  "name": "testfire",
-						  "extension": "net",
-						  "whois_server": "whois.registrar.amazon",
-						  "status": [
-							"clientDeleteProhibited",
-							"clientTransferProhibited",
-							"clientUpdateProhibited"
-						  ],
-						  "name_servers": [
-							"asia3.akam.net"
-						  ],
-						  "created_date": "1999-07-23T13:52:32Z",
-						  "created_date_in_time": "1999-07-23T13:52:32Z",
-						  "updated_date": "2025-02-27T17:53:33Z",
-						  "updated_date_in_time": "2025-02-27T17:53:33Z",
-						  "expiration_date": "2026-07-23T13:52:32Z",
-						  "expiration_date_in_time": "2026-07-23T13:52:32Z"
-						}
-					  }
+						"emails": [],
+						"subdomains": ["http://example.com"]
 					}
 				}
 			}`),
@@ -121,10 +98,12 @@ func TestProcessWhoIsEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewWhoIsHandler(tt.scanService)
+			h := NewHarvesterHandler(tt.scanService)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			err := h.processWhoIsEvent(ctx, tt.data)
+
+			err := h.processHarvesterEvent(ctx, tt.data)
+
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)
 			} else {

--- a/pkg/events/consumers/scanfailed.go
+++ b/pkg/events/consumers/scanfailed.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"runtime/debug"
+	"time"
 
 	"github.com/kptm-tools/common/common/pkg/events"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
@@ -21,30 +23,49 @@ func NewScanFailedHandler(scanService interfaces.IScanService) *ScanFailedHandle
 var _ interfaces.EventConsumer = (*ScanFailedHandler)(nil)
 
 func (h *ScanFailedHandler) HandleMessage(msg *nats.Msg) {
-	go func(msg *nats.Msg) {
-		ctx := context.Background()
-		slog.Info("Received ScanFailedEvent")
-
-		// 1. Parse payload
-		var evt events.ScanFailedEvent
-		if err := json.Unmarshal(msg.Data, &evt); err != nil {
-			slog.Error("Failed to unmarshal ScanFailedEvent", slog.Any("error", err))
-			return
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic recovered in ScanFailedHandler", "panic", r, "stack", string(debug.Stack()))
 		}
+	}()
+	slog.Info("Received ScanFailedEvent")
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Second)
+	defer cancel()
+	go h.processScanFailedEventRoutine(ctx, msg.Data)
+	<-ctx.Done()
+}
 
-		// 2. Log the reason
-		slog.Info("Scan failed",
+func (h *ScanFailedHandler) processScanFailedEventRoutine(ctx context.Context, data []byte) {
+	select {
+	case <-ctx.Done():
+		slog.Debug("ScanFailedHandler context cancelled or timed out", slog.Any("error", ctx.Err()))
+	default:
+		err := h.processScanFailedEvent(ctx, data)
+		if err != nil {
+			slog.Debug("Error processing ScanFailedEvent", "error", err)
+		}
+	}
+}
+
+func (h *ScanFailedHandler) processScanFailedEvent(ctx context.Context, data []byte) error {
+	// 1. Parse payload
+	var evt events.ScanFailedEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		slog.Error("Failed to unmarshal ScanFailedEvent", slog.Any("error", err))
+		return err
+	}
+
+	// 2. Log the reason
+	slog.Info("Scan failed",
+		slog.String("scan_id", evt.ScanID.String()),
+		slog.String("reason", evt.Reason))
+
+	// 3. Update the scan's status on DB
+	if err := h.scanService.MarkScanAsFailed(ctx, evt.ScanID); err != nil {
+		slog.Error("Failed to update scan status",
 			slog.String("scan_id", evt.ScanID.String()),
-			slog.String("reason", evt.Reason))
-
-		// 3. Update the scan's status on DB
-		if err := h.scanService.MarkScanAsFailed(ctx, evt.ScanID); err != nil {
-			slog.Error("Failed to update scan status",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.Any("error", err))
-			return
-		}
-
-		slog.Debug("ScanFailedEvent handled successfully")
-	}(msg)
+			slog.Any("error", err))
+		return err
+	}
+	return nil
 }

--- a/pkg/events/consumers/scanfailed_test.go
+++ b/pkg/events/consumers/scanfailed_test.go
@@ -1,0 +1,56 @@
+package consumers
+
+import (
+	"context"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+	mockservices "github.com/kptm-tools/core-service/pkg/mocks/services"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessScanFailedEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		scanService   interfaces.IScanService
+		data          []byte
+		expectedError string
+	}{
+		{
+			name:          "Error with unmarshal",
+			scanService:   &mockservices.MockScanService{},
+			data:          []byte(``),
+			expectedError: "unexpected end of JSON input",
+		},
+		{
+			name: "Scan failed",
+			scanService: &mockservices.MockScanService{
+				MockMarkScanAsFailed: func(ctx context.Context, scanID uuid.UUID) error {
+					assert.Equal(t, "301524ab-5d78-4a74-b278-dcf279db9b42", scanID.String())
+					return nil
+				},
+			},
+			data: []byte(`{
+				"scan_id": "301524ab-5d78-4a74-b278-dcf279db9b42",
+				"reason": "Test failure reason"
+			}`),
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewScanFailedHandler(tt.scanService)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			err := h.processScanFailedEvent(ctx, tt.data)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/events/consumers/whois.go
+++ b/pkg/events/consumers/whois.go
@@ -3,7 +3,10 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"runtime/debug"
+	"time"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/events"
@@ -23,54 +26,75 @@ func NewWhoIsHandler(scanService interfaces.IScanService) *WhoIsHandler {
 var _ interfaces.EventConsumer = (*WhoIsHandler)(nil)
 
 func (h *WhoIsHandler) HandleMessage(msg *nats.Msg) {
-	go func(msg *nats.Msg) {
-		ctx := context.Background()
-		slog.Info("Received WhoIsEvent")
-
-		// 1. Parse payload
-		var evt events.ToolResultEvent
-		if err := json.Unmarshal(msg.Data, &evt); err != nil {
-			slog.Error("Failed to unmarshal ToolResultEvent", slog.Any("error", err))
-			return
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic recovered in WhoIsHandler", "panic", r, "stack", string(debug.Stack()))
 		}
+	}()
+	slog.Info("Received WhoIsEvent")
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Second)
+	defer cancel()
+	go h.processWhoIsEventRoutine(ctx, msg.Data)
+	<-ctx.Done()
+}
 
-		// 2. Validate contents
-		if evt.ToolResult.Tool != enums.ToolWhoIs {
-			slog.Error("Invalid toolName for WhoIsEvent",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)))
-			return
+func (h *WhoIsHandler) processWhoIsEventRoutine(ctx context.Context, data []byte) {
+	select {
+	case <-ctx.Done():
+		slog.Debug("WhoIsHandler context cancelled or timed out", slog.Any("error", ctx.Err()))
+	default:
+		err := h.processWhoIsEvent(ctx, data)
+		if err != nil {
+			slog.Debug("Error processing WhoIsEvent", "error", err)
 		}
+	}
+}
 
-		// 2.1 Check if the current scan status is still healthy
-		actualScan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
-		if errScan != nil {
-			slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
-			return
-		}
-		if actualScan.IsFailedOrCancelled() {
-			slog.Error("Error inserting ScanResult to DB because of Scan Status",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("Status ", actualScan.Status),
-			)
-			return
-		}
+func (h *WhoIsHandler) processWhoIsEvent(ctx context.Context, data []byte) error {
+	// 1. Parse payload
+	var evt events.ToolResultEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		slog.Error("Failed to unmarshal ToolResultEvent", slog.Any("error", err))
+		return err
+	}
 
-		// 2.2 Check for errors in the result
-		handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
+	// 2. Validate contents
+	if evt.ToolResult.Tool != enums.ToolWhoIs {
+		slog.Error("Invalid toolName for WhoIsEvent",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)))
+		return errors.New("invalid toolName for WhoIsEvent")
+	}
 
-		// 3. Save ToolResult to DB
+	// 2.1 Check if the current scan status is still healthy
+	actualScan, errScan := h.scanService.GetScanByID(ctx, evt.ScanID)
+	if errScan != nil {
+		slog.Error("Failed to get Scan", slog.String("scan_id", evt.ScanID.String()))
+		return errScan
+	}
+	if actualScan.IsFailedOrCancelled() {
+		slog.Error("Error inserting ScanResult to DB because of Scan Status",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("Status ", actualScan.Status),
+		)
+		return errors.New("error inserting ScanResult to DB of Scan Status")
+	}
 
-		scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
-		if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
-			slog.Error("Error inserting ScanResult to DB",
-				slog.String("scan_id", evt.ScanID.String()),
-				slog.String("tool_name", string(evt.ToolResult.Tool)),
-				slog.Any("error", err))
-			return
-		}
+	// 2.2 Check for errors in the result
+	handleToolResultError(ctx, evt.ScanID, evt.ToolResult, h.scanService)
 
-		slog.Debug("WhoIsEvent handled successfully")
-	}(msg)
+	// 3. Save ToolResult to DB
+
+	scanResult := domain.NewScanResult(evt.ScanID, evt.ToolResult)
+	if err := h.scanService.InsertScanResult(ctx, *scanResult); err != nil {
+		slog.Error("Error inserting ScanResult to DB",
+			slog.String("scan_id", evt.ScanID.String()),
+			slog.String("tool_name", string(evt.ToolResult.Tool)),
+			slog.Any("error", err))
+		return err
+	}
+
+	slog.Debug("WhoIsEvent handled successfully")
+	return nil
 }

--- a/pkg/events/consumers/whois.go
+++ b/pkg/events/consumers/whois.go
@@ -78,7 +78,7 @@ func (h *WhoIsHandler) processWhoIsEvent(ctx context.Context, data []byte) error
 			slog.String("tool_name", string(evt.ToolResult.Tool)),
 			slog.Any("Status ", actualScan.Status),
 		)
-		return errors.New("error inserting ScanResult to DB of Scan Status")
+		return errors.New("cannot insert scan result: scan is failed or cancelled")
 	}
 
 	// 2.2 Check for errors in the result

--- a/pkg/events/consumers/whois_test.go
+++ b/pkg/events/consumers/whois_test.go
@@ -1,0 +1,68 @@
+package consumers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
+	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/interfaces"
+	mock_services "github.com/kptm-tools/core-service/pkg/mocks/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessWhoIsEvent(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		scanService   interfaces.IScanService
+		data          []byte
+		expectedError string
+	}{
+		{
+			name:          "Error with unmarshal",
+			scanService:   &mock_services.MockScanService{},
+			data:          []byte(``),
+			expectedError: "unexpected end of JSON input",
+		},
+		{
+			name:          "Invalid tool name",
+			scanService:   &mock_services.MockScanService{},
+			data:          []byte(`{}`),
+			expectedError: "invalid toolName for WhoIsEvent",
+		},
+		{
+			name: "Scan not found",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return nil, customerrors.ErrScanNotFound
+				},
+			},
+			data: []byte(`{
+							  "scan_id": "123e4567-e89b-12d3-a456-426614174000",
+							  "timestamp": "2025-07-07T12:34:56Z",
+                              "ToolResult": {"tool_name": "WhoIs",
+                              "result": null,
+							  "error": null,
+							  "timestamp": "2025-07-07T12:34:56Z"
+							}}`),
+			expectedError: "scan not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewWhoIsHandler(tt.scanService)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			err := h.processWhoIsEvent(ctx, tt.data)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## **Description:**
This PR refactors several event consumer handlers to follow a standardized design pattern, improving their **testability** and **maintainability**. The refactored handlers now separate business logic from the `HandleMessage` method, aligning with the pattern established in `WebScanHandler` and `NmapHandler`.

---

## **Key Changes:**
### 🔄 **Refactored Handlers:**
- `events/consumers/whois.go`
- `events/consumers/harvester.go`
- `events/consumers/dnslookup.go`
- `events/consumers/scanfailed.go`

### 🧩 **Design Improvements:**
- The `HandleMessage` method acts as a **thin orchestrator**, responsible for:
  - ✅ Creating a context with a timeout.
  - ✅ Launching the processing logic in a separate goroutine.
  - ✅ Handling panics gracefully.
- Core business logic is extracted into **separate, testable functions** (e.g., `processWhoisEvent(ctx, data)`).

### 🧪 **Unit Testing:**
- **New unit test files** created for each handler (e.g., `whois_test.go`).
- **Comprehensive unit tests** added for the new `process<EventName>Event` functions, covering:
  - ✅ Successful processing paths.
  - ✅ Error handling for invalid payloads (e.g., JSON unmarshalling failures).
  - ✅ Error handling for failed service calls.
  - ✅ Correct behavior for already failed or cancelled scans.
  - ✅ Context cancellation/timeout scenarios.
