### PR TITLE
Hotfix/down migrations fix

### DIFF
--- a/db/sql/migrations/000024_create_cwe_mitigations_table.down.sql
+++ b/db/sql/migrations/000024_create_cwe_mitigations_table.down.sql
@@ -1,9 +1,25 @@
 -- 000024_add_cwe_details_columns_and_create_cwe_mitigations.down.sql
 -- Re-add the old mitigation columns to cwe_details (if they do not already exist)
+-- First add columns as nullable
 ALTER     TABLE cwe_details
-ADD       COLUMN IF NOT EXISTS mitigation_phase VARCHAR(255) NOT NULL,
-ADD       COLUMN IF NOT EXISTS effectiveness VARCHAR(255) NOT NULL,
-ADD       COLUMN IF NOT EXISTS effectiveness_notes TEXT NOT NULL;
+ADD       COLUMN IF NOT EXISTS mitigation_phase VARCHAR(255),
+ADD       COLUMN IF NOT EXISTS effectiveness VARCHAR(255),
+ADD       COLUMN IF NOT EXISTS effectiveness_notes TEXT;
+
+-- Update with default values for existing rows
+UPDATE    cwe_details
+SET       mitigation_phase = 'Unknown',
+          effectiveness = 'Unknown',
+          effectiveness_notes = 'No notes available'
+WHERE     mitigation_phase IS NULL
+   OR     effectiveness IS NULL
+   OR     effectiveness_notes IS NULL;
+
+-- Now make the columns NOT NULL
+ALTER     TABLE cwe_details
+ALTER     COLUMN mitigation_phase SET NOT NULL,
+ALTER     COLUMN effectiveness SET NOT NULL,
+ALTER     COLUMN effectiveness_notes SET NOT NULL;
 
 -- Remove the newly added columns from cwe_details
 ALTER     TABLE cwe_details

--- a/db/sql/migrations/000028_drop_table_wasc_details.up.sql
+++ b/db/sql/migrations/000028_drop_table_wasc_details.up.sql
@@ -5,6 +5,11 @@ ALTER TABLE vulnerabilities
 
 -- Drop the index on wasc_id
 DROP INDEX IF EXISTS idx_vulnerabilities_wasc_id;
+
+-- Drop the wasc_id column from vulnerabilities table
+ALTER TABLE vulnerabilities
+    DROP COLUMN IF EXISTS wasc_id;
+
 -- Drop the wasc_details table
 DROP TABLE IF EXISTS wasc_details;
 


### PR DESCRIPTION
This pull request includes database schema changes to improve data integrity and clean up unused columns and tables. The most important changes involve modifying the `cwe_details` table to handle nullable columns before enforcing `NOT NULL` constraints and removing the `wasc_id` column and associated table from the database.

### Changes to improve data integrity:

* [`db/sql/migrations/000024_create_cwe_mitigations_table.down.sql`](diffhunk://#diff-786ad1bf892f61f77d1f3e85927ec81d2b45ada5d22527039cb8a7dd1b1e0e73R3-R22): Updated the `cwe_details` table to add previously removed columns (`mitigation_phase`, `effectiveness`, `effectiveness_notes`) as nullable, populate them with default values for existing rows, and then enforce `NOT NULL` constraints.

### Cleanup of unused database schema:

* [`db/sql/migrations/000028_drop_table_wasc_details.up.sql`](diffhunk://#diff-1a53039e63ecff7df3915298553ab4324bc1b0b90be8687f08bbc3ca7a7db046R8-R12): Removed the `wasc_id` column from the `vulnerabilities` table and dropped the `wasc_details` table to clean up unused schema elements.