### PR TITLE
Bug/kt 534 refactor schema to correctly place wasc id in web vulnerabilities table

### DIFF
--- a/db/models.go
+++ b/db/models.go
@@ -430,7 +430,6 @@ type Vulnerability struct {
 	CreatedAt      sql.NullTime          `json:"created_at"`
 	UpdatedAt      sql.NullTime          `json:"updated_at"`
 	CweID          sql.NullString        `json:"cwe_id"`
-	WascID         sql.NullString        `json:"wasc_id"`
 }
 
 type WebVulnerability struct {
@@ -442,6 +441,7 @@ type WebVulnerability struct {
 	Reference       sql.NullString `json:"reference"`
 	CreatedAt       sql.NullTime   `json:"created_at"`
 	UpdatedAt       sql.NullTime   `json:"updated_at"`
+	WascID          sql.NullString `json:"wasc_id"`
 }
 
 type WebVulnerabilityInstance struct {

--- a/db/sql/migrations/000024_create_cwe_mitigations_table.down.sql
+++ b/db/sql/migrations/000024_create_cwe_mitigations_table.down.sql
@@ -1,9 +1,25 @@
 -- 000024_add_cwe_details_columns_and_create_cwe_mitigations.down.sql
 -- Re-add the old mitigation columns to cwe_details (if they do not already exist)
+-- First add columns as nullable
 ALTER     TABLE cwe_details
-ADD       COLUMN IF NOT EXISTS mitigation_phase VARCHAR(255) NOT NULL,
-ADD       COLUMN IF NOT EXISTS effectiveness VARCHAR(255) NOT NULL,
-ADD       COLUMN IF NOT EXISTS effectiveness_notes TEXT NOT NULL;
+ADD       COLUMN IF NOT EXISTS mitigation_phase VARCHAR(255),
+ADD       COLUMN IF NOT EXISTS effectiveness VARCHAR(255),
+ADD       COLUMN IF NOT EXISTS effectiveness_notes TEXT;
+
+-- Update with default values for existing rows
+UPDATE    cwe_details
+SET       mitigation_phase = 'Unknown',
+          effectiveness = 'Unknown',
+          effectiveness_notes = 'No notes available'
+WHERE     mitigation_phase IS NULL
+   OR     effectiveness IS NULL
+   OR     effectiveness_notes IS NULL;
+
+-- Now make the columns NOT NULL
+ALTER     TABLE cwe_details
+ALTER     COLUMN mitigation_phase SET NOT NULL,
+ALTER     COLUMN effectiveness SET NOT NULL,
+ALTER     COLUMN effectiveness_notes SET NOT NULL;
 
 -- Remove the newly added columns from cwe_details
 ALTER     TABLE cwe_details

--- a/db/sql/migrations/000028_drop_table_wasc_details.down.sql
+++ b/db/sql/migrations/000028_drop_table_wasc_details.down.sql
@@ -1,18 +1,9 @@
 -- Migration: 000028_drop_table_wasc_details.down.sql
+-- Only recreate the wasc_details table
+-- The wasc_id column and its constraints are now handled by migration 25
 CREATE TABLE IF NOT EXISTS wasc_details (
     wasc_id VARCHAR(255) PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
     description TEXT NOT NULL,
     last_updated TIMESTAMP WITH TIME ZONE NOT NULL
-                               );
-
-ALTER TABLE vulnerabilities
-    ADD COLUMN wasc_id VARCHAR(255);
-
-ALTER TABLE vulnerabilities
-    ADD CONSTRAINT fk_vulnerabilities_wasc_details
-        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
-            ON DELETE SET NULL
-            ON UPDATE CASCADE;
-
-CREATE INDEX idx_vulnerabilities_wasc_id ON vulnerabilities (wasc_id);
+);

--- a/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.down.sql
+++ b/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.down.sql
@@ -1,0 +1,34 @@
+-- Migration: 000029_move_wasc_id_to_web_vulnerabilities.down.sql
+-- Move wasc_id back from web_vulnerabilities table to vulnerabilities table
+
+-- First, add wasc_id column back to vulnerabilities table
+ALTER TABLE vulnerabilities
+    ADD COLUMN IF NOT EXISTS wasc_id VARCHAR(255);
+
+-- Copy wasc_id data from web_vulnerabilities back to vulnerabilities
+UPDATE vulnerabilities v
+SET wasc_id = wv.wasc_id
+FROM web_vulnerabilities wv
+WHERE v.id = wv.vulnerability_id
+  AND wv.wasc_id IS NOT NULL;
+
+-- Add foreign key constraint back to vulnerabilities table
+ALTER TABLE vulnerabilities
+    ADD CONSTRAINT fk_vulnerabilities_wasc_details
+        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
+            ON DELETE SET NULL
+            ON UPDATE CASCADE;
+
+-- Create index on wasc_id in vulnerabilities table
+CREATE INDEX idx_vulnerabilities_wasc_id ON vulnerabilities (wasc_id);
+
+-- Drop the foreign key constraint from web_vulnerabilities table
+ALTER TABLE web_vulnerabilities
+    DROP CONSTRAINT IF EXISTS fk_web_vulnerabilities_wasc_details;
+
+-- Drop the index on wasc_id in web_vulnerabilities table
+DROP INDEX IF EXISTS idx_web_vulnerabilities_wasc_id;
+
+-- Finally, drop the wasc_id column from web_vulnerabilities table
+ALTER TABLE web_vulnerabilities
+    DROP COLUMN IF EXISTS wasc_id;

--- a/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.down.sql
+++ b/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.down.sql
@@ -12,19 +12,8 @@ FROM web_vulnerabilities wv
 WHERE v.id = wv.vulnerability_id
   AND wv.wasc_id IS NOT NULL;
 
--- Add foreign key constraint back to vulnerabilities table
-ALTER TABLE vulnerabilities
-    ADD CONSTRAINT fk_vulnerabilities_wasc_details
-        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
-            ON DELETE SET NULL
-            ON UPDATE CASCADE;
-
 -- Create index on wasc_id in vulnerabilities table
-CREATE INDEX idx_vulnerabilities_wasc_id ON vulnerabilities (wasc_id);
-
--- Drop the foreign key constraint from web_vulnerabilities table
-ALTER TABLE web_vulnerabilities
-    DROP CONSTRAINT IF EXISTS fk_web_vulnerabilities_wasc_details;
+CREATE INDEX IF NOT EXISTS idx_vulnerabilities_wasc_id ON vulnerabilities (wasc_id);
 
 -- Drop the index on wasc_id in web_vulnerabilities table
 DROP INDEX IF EXISTS idx_web_vulnerabilities_wasc_id;

--- a/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.up.sql
+++ b/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.up.sql
@@ -6,30 +6,34 @@
 ALTER TABLE web_vulnerabilities
     ADD COLUMN IF NOT EXISTS wasc_id VARCHAR(255);
 
--- Copy existing wasc_id data from vulnerabilities to web_vulnerabilities
-UPDATE web_vulnerabilities wv
-SET wasc_id = v.wasc_id
-FROM vulnerabilities v
-WHERE wv.vulnerability_id = v.id
-  AND v.wasc_id IS NOT NULL;
-
--- Add foreign key constraint for wasc_id in web_vulnerabilities
-ALTER TABLE web_vulnerabilities
-    ADD CONSTRAINT fk_web_vulnerabilities_wasc_details
-        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
-            ON DELETE SET NULL
-            ON UPDATE CASCADE;
+-- Only copy data if wasc_id column exists in vulnerabilities table
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'vulnerabilities'
+        AND column_name = 'wasc_id'
+    ) THEN
+        -- Copy existing wasc_id data from vulnerabilities to web_vulnerabilities
+        UPDATE web_vulnerabilities wv
+        SET wasc_id = v.wasc_id
+        FROM vulnerabilities v
+        WHERE wv.vulnerability_id = v.id
+          AND v.wasc_id IS NOT NULL;
+    END IF;
+END $$;
 
 -- Create index on wasc_id in web_vulnerabilities
-CREATE INDEX idx_web_vulnerabilities_wasc_id ON web_vulnerabilities (wasc_id);
+CREATE INDEX IF NOT EXISTS idx_web_vulnerabilities_wasc_id ON web_vulnerabilities (wasc_id);
 
--- Drop the foreign key constraint from vulnerabilities table
+-- Drop the foreign key constraint from vulnerabilities table if it exists
 ALTER TABLE vulnerabilities
     DROP CONSTRAINT IF EXISTS fk_vulnerabilities_wasc_details;
 
--- Drop the index on wasc_id in vulnerabilities table
+-- Drop the index on wasc_id in vulnerabilities table if it exists
 DROP INDEX IF EXISTS idx_vulnerabilities_wasc_id;
 
--- Finally, drop the wasc_id column from vulnerabilities table
+-- Finally, drop the wasc_id column from vulnerabilities table if it exists
 ALTER TABLE vulnerabilities
     DROP COLUMN IF EXISTS wasc_id;

--- a/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.up.sql
+++ b/db/sql/migrations/000029_move_wasc_id_to_web_vulnerabilities.up.sql
@@ -1,0 +1,35 @@
+-- Migration: 000029_move_wasc_id_to_web_vulnerabilities.up.sql
+-- Move wasc_id from vulnerabilities table to web_vulnerabilities table
+-- to comply with class table inheritance pattern (ADR-003)
+
+-- First, add wasc_id column to web_vulnerabilities table
+ALTER TABLE web_vulnerabilities
+    ADD COLUMN IF NOT EXISTS wasc_id VARCHAR(255);
+
+-- Copy existing wasc_id data from vulnerabilities to web_vulnerabilities
+UPDATE web_vulnerabilities wv
+SET wasc_id = v.wasc_id
+FROM vulnerabilities v
+WHERE wv.vulnerability_id = v.id
+  AND v.wasc_id IS NOT NULL;
+
+-- Add foreign key constraint for wasc_id in web_vulnerabilities
+ALTER TABLE web_vulnerabilities
+    ADD CONSTRAINT fk_web_vulnerabilities_wasc_details
+        FOREIGN KEY (wasc_id) REFERENCES wasc_details (wasc_id)
+            ON DELETE SET NULL
+            ON UPDATE CASCADE;
+
+-- Create index on wasc_id in web_vulnerabilities
+CREATE INDEX idx_web_vulnerabilities_wasc_id ON web_vulnerabilities (wasc_id);
+
+-- Drop the foreign key constraint from vulnerabilities table
+ALTER TABLE vulnerabilities
+    DROP CONSTRAINT IF EXISTS fk_vulnerabilities_wasc_details;
+
+-- Drop the index on wasc_id in vulnerabilities table
+DROP INDEX IF EXISTS idx_vulnerabilities_wasc_id;
+
+-- Finally, drop the wasc_id column from vulnerabilities table
+ALTER TABLE vulnerabilities
+    DROP COLUMN IF EXISTS wasc_id;

--- a/db/sql/queries/vulnerability.sql
+++ b/db/sql/queries/vulnerability.sql
@@ -9,10 +9,9 @@ INSERT INTO vulnerabilities (
     severity,
     vuln_source,
     vuln_type,
-    analyst_comment,
-    wasc_id
+    analyst_comment
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 )
 ON CONFLICT (host_id, scan_id, cve_id) DO UPDATE SET
   title = EXCLUDED.title,

--- a/db/sql/queries/web_vulnerability.sql
+++ b/db/sql/queries/web_vulnerability.sql
@@ -5,9 +5,10 @@ INSERT INTO web_vulnerabilities (
   host_id,
   service_id,
   solution_advice,
-  reference
+  reference,
+  wasc_id
 ) VALUES (
-  $1, $2, $3, $4, $5, $6
+  $1, $2, $3, $4, $5, $6, $7
 )
 RETURNING *;
 

--- a/db/vulnerability.sql.go
+++ b/db/vulnerability.sql.go
@@ -45,10 +45,9 @@ INSERT INTO vulnerabilities (
     severity,
     vuln_source,
     vuln_type,
-    analyst_comment,
-    wasc_id
+    analyst_comment
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 )
 ON CONFLICT (host_id, scan_id, cve_id) DO UPDATE SET
   title = EXCLUDED.title,
@@ -58,7 +57,7 @@ ON CONFLICT (host_id, scan_id, cve_id) DO UPDATE SET
   vuln_type = EXCLUDED.vuln_type,
   analyst_comment = EXCLUDED.analyst_comment,
   updated_at = NOW()
-RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id, wasc_id
+RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id
 `
 
 type CreateVulnerabilityParams struct {
@@ -72,7 +71,6 @@ type CreateVulnerabilityParams struct {
 	VulnSource     string                `json:"vuln_source"`
 	VulnType       VulnerabilityTypeEnum `json:"vuln_type"`
 	AnalystComment sql.NullString        `json:"analyst_comment"`
-	WascID         sql.NullString        `json:"wasc_id"`
 }
 
 func (q *Queries) CreateVulnerability(ctx context.Context, arg CreateVulnerabilityParams) (Vulnerability, error) {
@@ -87,7 +85,6 @@ func (q *Queries) CreateVulnerability(ctx context.Context, arg CreateVulnerabili
 		arg.VulnSource,
 		arg.VulnType,
 		arg.AnalystComment,
-		arg.WascID,
 	)
 	var i Vulnerability
 	err := row.Scan(
@@ -104,7 +101,6 @@ func (q *Queries) CreateVulnerability(ctx context.Context, arg CreateVulnerabili
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CweID,
-		&i.WascID,
 	)
 	return i, err
 }
@@ -115,7 +111,7 @@ SET
     analyst_comment = NULL,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
-RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id, wasc_id
+RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id
 `
 
 func (q *Queries) DeleteVulnerabilityComment(ctx context.Context, id uuid.UUID) (Vulnerability, error) {
@@ -135,7 +131,6 @@ func (q *Queries) DeleteVulnerabilityComment(ctx context.Context, id uuid.UUID) 
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CweID,
-		&i.WascID,
 	)
 	return i, err
 }
@@ -315,7 +310,7 @@ func (q *Queries) GetScanVulnerabilityAggregatesByScanID(ctx context.Context, ar
 }
 
 const getVulnerabilitiesByScanID = `-- name: GetVulnerabilitiesByScanID :many
-SELECT id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id, wasc_id
+SELECT id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id
 FROM vulnerabilities
 WHERE scan_id = $1
 ORDER BY cve_id DESC
@@ -344,7 +339,6 @@ func (q *Queries) GetVulnerabilitiesByScanID(ctx context.Context, scanID uuid.UU
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.CweID,
-			&i.WascID,
 		); err != nil {
 			return nil, err
 		}
@@ -361,7 +355,7 @@ func (q *Queries) GetVulnerabilitiesByScanID(ctx context.Context, scanID uuid.UU
 
 const getVulnerabilitiesWithDetailsByScanID = `-- name: GetVulnerabilitiesWithDetailsByScanID :many
 SELECT 
-  v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id, v.wasc_id,
+  v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id,
   cve.id, cve.cve_id, cve.published_date, cve.last_modified_date, cve.cvss_v2_vector, cve.cvss_v2_base_score, cve.cvss_v2_base_severity, cve.cvss_v2_exploitability_score, cve.cvss_v2_impact_score, cve.cvss_v2_access_vector, cve.cvss_v2_access_complexity, cve.cvss_v2_authentication, cve.cvss_v2_confidentiality_impact, cve.cvss_v2_integrity_impact, cve.cvss_v2_availability_impact, cve.cvss_v30_vector, cve.cvss_v30_base_score, cve.cvss_v30_base_severity, cve.cvss_v30_exploitability_score, cve.cvss_v30_impact_score, cve.cvss_v30_attack_vector, cve.cvss_v30_attack_complexity, cve.cvss_v30_privileges_required, cve.cvss_v30_user_interaction, cve.cvss_v30_scope, cve.cvss_v30_confidentiality_impact, cve.cvss_v30_integrity_impact, cve.cvss_v30_availability_impact, cve.cvss_v31_vector, cve.cvss_v31_base_score, cve.cvss_v31_base_severity, cve.cvss_v31_exploitability_score, cve.cvss_v31_exploit_code_maturity, cve.cvss_v31_impact_score, cve.cvss_v31_attack_vector, cve.cvss_v31_attack_complexity, cve.cvss_v31_privileges_required, cve.cvss_v31_user_interaction, cve.cvss_v31_scope, cve.cvss_v31_confidentiality_impact, cve.cvss_v31_integrity_impact, cve.cvss_v31_availability_impact, cve.epss_score, cve.epss_percentile, cve.risk_score, cve.likelihood, cve.nvd_description, cve.nvd_references, cve.vendor_comments, cve.created_at, cve.updated_at,
   cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at
 FROM
@@ -390,7 +384,6 @@ type GetVulnerabilitiesWithDetailsByScanIDRow struct {
 	CreatedAt                    sql.NullTime          `json:"created_at"`
 	UpdatedAt                    sql.NullTime          `json:"updated_at"`
 	CweID                        sql.NullString        `json:"cwe_id"`
-	WascID                       sql.NullString        `json:"wasc_id"`
 	ID_2                         uuid.NullUUID         `json:"id_2"`
 	CveID_2                      sql.NullString        `json:"cve_id_2"`
 	PublishedDate                sql.NullTime          `json:"published_date"`
@@ -472,7 +465,6 @@ func (q *Queries) GetVulnerabilitiesWithDetailsByScanID(ctx context.Context, sca
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.CweID,
-			&i.WascID,
 			&i.ID_2,
 			&i.CveID_2,
 			&i.PublishedDate,
@@ -544,7 +536,7 @@ func (q *Queries) GetVulnerabilitiesWithDetailsByScanID(ctx context.Context, sca
 }
 
 const getVulnerabilityByID = `-- name: GetVulnerabilityByID :one
-SELECT id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id, wasc_id
+SELECT id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id
 FROM vulnerabilities
 WHERE id = $1
 LIMIT 1
@@ -567,7 +559,6 @@ func (q *Queries) GetVulnerabilityByID(ctx context.Context, id uuid.UUID) (Vulne
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CweID,
-		&i.WascID,
 	)
 	return i, err
 }
@@ -693,7 +684,7 @@ func (q *Queries) GetVulnerabilityWithCommentStatus(ctx context.Context, id uuid
 
 const getVulnerabilityWithDetailsByID = `-- name: GetVulnerabilityWithDetailsByID :one
 SELECT 
-  v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id, v.wasc_id,
+  v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id,
   cve.id, cve.cve_id, cve.published_date, cve.last_modified_date, cve.cvss_v2_vector, cve.cvss_v2_base_score, cve.cvss_v2_base_severity, cve.cvss_v2_exploitability_score, cve.cvss_v2_impact_score, cve.cvss_v2_access_vector, cve.cvss_v2_access_complexity, cve.cvss_v2_authentication, cve.cvss_v2_confidentiality_impact, cve.cvss_v2_integrity_impact, cve.cvss_v2_availability_impact, cve.cvss_v30_vector, cve.cvss_v30_base_score, cve.cvss_v30_base_severity, cve.cvss_v30_exploitability_score, cve.cvss_v30_impact_score, cve.cvss_v30_attack_vector, cve.cvss_v30_attack_complexity, cve.cvss_v30_privileges_required, cve.cvss_v30_user_interaction, cve.cvss_v30_scope, cve.cvss_v30_confidentiality_impact, cve.cvss_v30_integrity_impact, cve.cvss_v30_availability_impact, cve.cvss_v31_vector, cve.cvss_v31_base_score, cve.cvss_v31_base_severity, cve.cvss_v31_exploitability_score, cve.cvss_v31_exploit_code_maturity, cve.cvss_v31_impact_score, cve.cvss_v31_attack_vector, cve.cvss_v31_attack_complexity, cve.cvss_v31_privileges_required, cve.cvss_v31_user_interaction, cve.cvss_v31_scope, cve.cvss_v31_confidentiality_impact, cve.cvss_v31_integrity_impact, cve.cvss_v31_availability_impact, cve.epss_score, cve.epss_percentile, cve.risk_score, cve.likelihood, cve.nvd_description, cve.nvd_references, cve.vendor_comments, cve.created_at, cve.updated_at,
   cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at
 FROM
@@ -720,7 +711,6 @@ type GetVulnerabilityWithDetailsByIDRow struct {
 	CreatedAt                    sql.NullTime          `json:"created_at"`
 	UpdatedAt                    sql.NullTime          `json:"updated_at"`
 	CweID                        sql.NullString        `json:"cwe_id"`
-	WascID                       sql.NullString        `json:"wasc_id"`
 	ID_2                         uuid.NullUUID         `json:"id_2"`
 	CveID_2                      sql.NullString        `json:"cve_id_2"`
 	PublishedDate                sql.NullTime          `json:"published_date"`
@@ -796,7 +786,6 @@ func (q *Queries) GetVulnerabilityWithDetailsByID(ctx context.Context, id uuid.U
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CweID,
-		&i.WascID,
 		&i.ID_2,
 		&i.CveID_2,
 		&i.PublishedDate,
@@ -863,7 +852,7 @@ SET
     analyst_comment = $2,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
-RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id, wasc_id
+RETURNING id, host_id, scan_id, cve_id, title, description, severity, vuln_source, vuln_type, analyst_comment, created_at, updated_at, cwe_id
 `
 
 type UpdateVulnerabilityCommentParams struct {
@@ -888,7 +877,6 @@ func (q *Queries) UpdateVulnerabilityComment(ctx context.Context, arg UpdateVuln
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CweID,
-		&i.WascID,
 	)
 	return i, err
 }

--- a/db/web_vulnerability.sql.go
+++ b/db/web_vulnerability.sql.go
@@ -19,11 +19,12 @@ INSERT INTO web_vulnerabilities (
   host_id,
   service_id,
   solution_advice,
-  reference
+  reference,
+  wasc_id
 ) VALUES (
-  $1, $2, $3, $4, $5, $6
+  $1, $2, $3, $4, $5, $6, $7
 )
-RETURNING vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at
+RETURNING vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at, wasc_id
 `
 
 type CreateWebVulnerabilityParams struct {
@@ -33,6 +34,7 @@ type CreateWebVulnerabilityParams struct {
 	ServiceID       int32          `json:"service_id"`
 	SolutionAdvice  sql.NullString `json:"solution_advice"`
 	Reference       sql.NullString `json:"reference"`
+	WascID          sql.NullString `json:"wasc_id"`
 }
 
 func (q *Queries) CreateWebVulnerability(ctx context.Context, arg CreateWebVulnerabilityParams) (WebVulnerability, error) {
@@ -43,6 +45,7 @@ func (q *Queries) CreateWebVulnerability(ctx context.Context, arg CreateWebVulne
 		arg.ServiceID,
 		arg.SolutionAdvice,
 		arg.Reference,
+		arg.WascID,
 	)
 	var i WebVulnerability
 	err := row.Scan(
@@ -54,12 +57,13 @@ func (q *Queries) CreateWebVulnerability(ctx context.Context, arg CreateWebVulne
 		&i.Reference,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.WascID,
 	)
 	return i, err
 }
 
 const getWebVulnerabilityByID = `-- name: GetWebVulnerabilityByID :one
-SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at
+SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at, wasc_id
 FROM web_vulnerabilities
 WHERE vulnerability_id = $1
 `
@@ -76,12 +80,13 @@ func (q *Queries) GetWebVulnerabilityByID(ctx context.Context, vulnerabilityID u
 		&i.Reference,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.WascID,
 	)
 	return i, err
 }
 
 const listWebVulnerabilitiesByScanID = `-- name: ListWebVulnerabilitiesByScanID :many
-SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at
+SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at, wasc_id
 FROM web_vulnerabilities
 WHERE scan_id = $1
 `
@@ -104,6 +109,7 @@ func (q *Queries) ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uui
 			&i.Reference,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.WascID,
 		); err != nil {
 			return nil, err
 		}
@@ -120,7 +126,7 @@ func (q *Queries) ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uui
 
 const listWebVulnerabilitiesByServiceID = `-- name: ListWebVulnerabilitiesByServiceID :many
 SELECT I.uri, I.method, I.param, I.evidence, I.other_info, I.attack, W.vulnerability_id, W.scan_id, W.host_id, W.service_id, W.solution_advice, W.reference, W.created_at, W.updated_at
-FROM (SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at FROM web_vulnerabilities WHERE service_id=$1) W
+FROM (SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at, wasc_id FROM web_vulnerabilities WHERE service_id=$1) W
 INNER JOIN (SELECT id FROM vulnerabilities WHERE vuln_type ='WEB_APPLICATION') V
 ON W.vulnerability_id=V.id
 LEFT JOIN web_vulnerability_instances I ON W.vulnerability_id=I.source_vulnerability_id

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -157,6 +157,7 @@ type WebVulnerability struct {
 	SolutionAdvice  string                     `json:"solution_advice"`
 	Reference       string                     `json:"reference"`
 	OtherInfo       string                     `json:"other_info"`
+	WascID          *string                    `json:"wasc_id,omitempty"`
 	CreatedAt       *time.Time                 `json:"created_at"`
 	UpdatedAt       *time.Time                 `json:"updated_at"`
 	Instances       []WebVulnerabilityInstance `json:"instances"`

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -57,7 +57,7 @@ type VulnerabilityRepository interface {
 	GetSeverityServiceCountsByScanAndServiceID(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error)
 	GetVulnerabilityCategoriesByScan(context.Context, dto.VulnerabilityCategoriesParams) ([]domain.ServiceCategoryData, error)
 	GetHostVulnerabilityTrends(context.Context, dto.VulnerabilityTrendsParams) ([]domain.ServiceTimePeriod, error)
-	CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error)
+	CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error)
 	CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error
 	GetWebVulnerabilityByID(ctx context.Context, vulnID uuid.UUID) (*domain.WebVulnerability, error)
 	ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uuid.UUID) ([]domain.WebVulnerability, error)

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -58,7 +58,7 @@ type VulnerabilityRepository interface {
 	GetVulnerabilityCategoriesByScan(context.Context, dto.VulnerabilityCategoriesParams) ([]domain.ServiceCategoryData, error)
 	GetHostVulnerabilityTrends(context.Context, dto.VulnerabilityTrendsParams) ([]domain.ServiceTimePeriod, error)
 	CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, webVuln tools.WebVulnerability) (*domain.WebVulnerability, error)
-	CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error
+	CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error
 	GetWebVulnerabilityByID(ctx context.Context, vulnID uuid.UUID) (*domain.WebVulnerability, error)
 	ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uuid.UUID) ([]domain.WebVulnerability, error)
 	CreateVulnerabilityFromWebVuln(ctx context.Context, hostID uuid.UUID, scanID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error)

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -57,7 +57,7 @@ type VulnerabilityRepository interface {
 	GetSeverityServiceCountsByScanAndServiceID(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error)
 	GetVulnerabilityCategoriesByScan(context.Context, dto.VulnerabilityCategoriesParams) ([]domain.ServiceCategoryData, error)
 	GetHostVulnerabilityTrends(context.Context, dto.VulnerabilityTrendsParams) ([]domain.ServiceTimePeriod, error)
-	CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error)
+	CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, webVuln tools.WebVulnerability) (*domain.WebVulnerability, error)
 	CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error
 	GetWebVulnerabilityByID(ctx context.Context, vulnID uuid.UUID) (*domain.WebVulnerability, error)
 	ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uuid.UUID) ([]domain.WebVulnerability, error)

--- a/pkg/mocks/storage/vulnerability.go
+++ b/pkg/mocks/storage/vulnerability.go
@@ -36,7 +36,7 @@ type MockVulnerabilityRepo struct {
 	MockGetVulnerabilityCategoriesByScan                             func(context.Context, dto.VulnerabilityCategoriesParams) ([]domain.ServiceCategoryData, error)
 	MockGetHostVulnerabilityTrends                                   func(context.Context, dto.VulnerabilityTrendsParams) ([]domain.ServiceTimePeriod, error)
 	MockCreateWebVulnerability                                       func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error)
-	MockCreateWebVulnerabilityInstance                               func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error
+	MockCreateWebVulnerabilityInstance                               func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error
 	MockGetWebVulnerabilityByID                                      func(ctx context.Context, vulnID uuid.UUID) (*domain.WebVulnerability, error)
 	MockListWebVulnerabilitiesByScanID                               func(ctx context.Context, scanID uuid.UUID) ([]domain.WebVulnerability, error)
 	MockCreateVulnerabilityFromWebVuln                               func(ctx context.Context, hostID uuid.UUID, scanID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error)
@@ -199,9 +199,9 @@ func (m *MockVulnerabilityRepo) CreateWebVulnerability(ctx context.Context, vuln
 	panic(fmt.Sprintf("MockVulnerabilityRepo: method CreateWebVulnerability called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }
 
-func (m *MockVulnerabilityRepo) CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+func (m *MockVulnerabilityRepo) CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 	if m.MockCreateWebVulnerabilityInstance != nil {
-		return m.MockCreateWebVulnerabilityInstance(ctx, vulnID, uri, method, param, attack, evidence, otherInfo)
+		return m.MockCreateWebVulnerabilityInstance(ctx, vulnID, instance)
 	}
 	panic(fmt.Sprintf("MockVulnerabilityRepo: method CreateWebVulnerabilityInstance called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }

--- a/pkg/mocks/storage/vulnerability.go
+++ b/pkg/mocks/storage/vulnerability.go
@@ -192,7 +192,7 @@ func (m *MockVulnerabilityRepo) GetHostVulnerabilityTrends(ctx context.Context, 
 	panic(fmt.Sprintf("MockVulnerabilityRepo: method GetHostVulnerabilityTrends called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }
 
-func (m *MockVulnerabilityRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
+func (m *MockVulnerabilityRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error) {
 	if m.MockCreateWebVulnerability != nil {
 		return m.MockCreateWebVulnerability(ctx, vulnID, scanID, hostID, serviceID, solution, reference)
 	}

--- a/pkg/mocks/storage/vulnerability.go
+++ b/pkg/mocks/storage/vulnerability.go
@@ -192,9 +192,9 @@ func (m *MockVulnerabilityRepo) GetHostVulnerabilityTrends(ctx context.Context, 
 	panic(fmt.Sprintf("MockVulnerabilityRepo: method GetHostVulnerabilityTrends called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }
 
-func (m *MockVulnerabilityRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error) {
+func (m *MockVulnerabilityRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, webVuln tools.WebVulnerability) (*domain.WebVulnerability, error) {
 	if m.MockCreateWebVulnerability != nil {
-		return m.MockCreateWebVulnerability(ctx, vulnID, scanID, hostID, serviceID, solution, reference)
+		return m.MockCreateWebVulnerability(ctx, vulnID, scanID, hostID, serviceID, webVuln.Solution, webVuln.Reference)
 	}
 	panic(fmt.Sprintf("MockVulnerabilityRepo: method CreateWebVulnerability called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -442,7 +442,11 @@ func (s *VulnerabilityService) InsertWebScanVulnerabilities(ctx context.Context,
 				return fmt.Errorf("failed to create vulnerability record for web scan vulnerability %s: %w", vuln.CweID, errCreateVuln)
 			}
 			// 2.1.4 Create a WebScan VulnerabilityRecord
-			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln.Solution, vuln.Reference, vuln.WascID)
+			var wascID *string
+			if vuln.WascID != "" {
+				wascID = &vuln.WascID
+			}
+			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln.Solution, vuln.Reference, wascID)
 			if errWebVuln != nil {
 				return fmt.Errorf("failed to create webScan vulnerability record: %w", err)
 			}

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -449,7 +449,7 @@ func (s *VulnerabilityService) InsertWebScanVulnerabilities(ctx context.Context,
 
 			// 2.1.5 Create a WebScan Detail VulnerabilityRecord
 			for _, vulnInstance := range vuln.Instances {
-				err = s.vulnerRepo.CreateWebVulnerabilityInstance(ctx, webVuln.VulnerabilityID, vulnInstance.URI, string(vulnInstance.Method), vulnInstance.Param, vulnInstance.Attack, vulnInstance.Evidence, vulnInstance.OtherInfo)
+				err = s.vulnerRepo.CreateWebVulnerabilityInstance(ctx, webVuln.VulnerabilityID, vulnInstance)
 				if err != nil {
 					return fmt.Errorf("failed to create webScan vulnerability instance: %w", err)
 				}

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -442,7 +442,7 @@ func (s *VulnerabilityService) InsertWebScanVulnerabilities(ctx context.Context,
 				return fmt.Errorf("failed to create vulnerability record for web scan vulnerability %s: %w", vuln.CweID, errCreateVuln)
 			}
 			// 2.1.4 Create a WebScan VulnerabilityRecord
-			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln.Solution, vuln.Reference)
+			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln.Solution, vuln.Reference, vuln.WascID)
 			if errWebVuln != nil {
 				return fmt.Errorf("failed to create webScan vulnerability record: %w", err)
 			}

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -442,11 +442,7 @@ func (s *VulnerabilityService) InsertWebScanVulnerabilities(ctx context.Context,
 				return fmt.Errorf("failed to create vulnerability record for web scan vulnerability %s: %w", vuln.CweID, errCreateVuln)
 			}
 			// 2.1.4 Create a WebScan VulnerabilityRecord
-			var wascID *string
-			if vuln.WascID != "" {
-				wascID = &vuln.WascID
-			}
-			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln.Solution, vuln.Reference, wascID)
+			webVuln, errWebVuln := s.vulnerRepo.CreateWebVulnerability(ctx, dbVuln.ID, scan.ID, scan.HostID, service.ID, vuln)
 			if errWebVuln != nil {
 				return fmt.Errorf("failed to create webScan vulnerability record: %w", err)
 			}

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -613,7 +613,7 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Success(t *testing.T)
 	mockVulnRepo.MockCreateWebVulnerability = func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
 		return &domain.WebVulnerability{}, nil
 	}
-	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 		return nil
 	}
 	// Act
@@ -697,7 +697,7 @@ func TestVulnerabilityService_CreateWebScanVulnerabilitiesWhenServiceNOTExists_S
 	mockVulnRepo.MockCreateWebVulnerability = func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
 		return &domain.WebVulnerability{}, nil
 	}
-	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 		return nil
 	}
 	// Act
@@ -790,7 +790,7 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_SuccessEvenIfCWEEmpty
 	mockVulnRepo.MockCreateWebVulnerability = func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
 		return &domain.WebVulnerability{}, nil
 	}
-	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 		return nil
 	}
 	// Act
@@ -883,7 +883,7 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_SuccessEvenIfWASCEmpt
 	mockVulnRepo.MockCreateWebVulnerability = func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
 		return &domain.WebVulnerability{}, nil
 	}
-	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 		return nil
 	}
 	// Act
@@ -1156,7 +1156,7 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Fail_WhenErrorWebVuln
 	mockVulnRepo.MockCreateWebVulnerability = func(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
 		return &domain.WebVulnerability{}, nil
 	}
-	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+	mockVulnRepo.MockCreateWebVulnerabilityInstance = func(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 		return errors.New("web vulnerability instance exists")
 	}
 	// Act

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -1127,25 +1127,25 @@ func buildSeverityWhereClause(severityFilters []string, queryParams []any) (stri
 	return severityWhereClause, queryParams
 }
 
-func (r *VulnerRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error) {
+func (r *VulnerRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, webVuln tools.WebVulnerability) (*domain.WebVulnerability, error) {
 	queries := r.getQueries(ctx)
 	params := repository.CreateWebVulnerabilityParams{
 		VulnerabilityID: vulnID,
 		ScanID:          scanID,
 		HostID:          hostID,
 		ServiceID:       serviceID,
-		SolutionAdvice:  sql.NullString{String: solution, Valid: true},
-		Reference:       sql.NullString{String: reference, Valid: true},
+		SolutionAdvice:  sql.NullString{String: webVuln.Solution, Valid: webVuln.Solution != ""},
+		Reference:       sql.NullString{String: webVuln.Reference, Valid: webVuln.Reference != ""},
 	}
-	if wascID != nil {
-		params.WascID = sql.NullString{String: *wascID, Valid: true}
+	if webVuln.WascID != "" {
+		params.WascID = sql.NullString{String: webVuln.WascID, Valid: true}
 	}
 	dbWebVuln, err := queries.CreateWebVulnerability(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	webVuln := r.fromDBtoDomainWebVuln(dbWebVuln)
-	return &webVuln, nil
+	domainWebVuln := r.fromDBtoDomainWebVuln(dbWebVuln)
+	return &domainWebVuln, nil
 }
 
 func (r *VulnerRepo) GetWebVulnerabilityByID(ctx context.Context, vulnID uuid.UUID) (*domain.WebVulnerability, error) {

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -1194,16 +1194,16 @@ func (r *VulnerRepo) fromDBtoDomainWebVuln(dbVuln repository.WebVulnerability) d
 	}
 }
 
-func (r *VulnerRepo) CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, uri, method, param, attack, evidence, otherInfo string) error {
+func (r *VulnerRepo) CreateWebVulnerabilityInstance(ctx context.Context, vulnID uuid.UUID, instance tools.InstanceAlert) error {
 	queries := r.getQueries(ctx)
 	params := repository.CreateWebVulnerabilityInstanceParams{
 		SourceVulnerabilityID: vulnID,
-		Uri:                   sql.NullString{String: uri, Valid: true},
-		Method:                sql.NullString{String: method, Valid: true},
-		Param:                 sql.NullString{String: param, Valid: true},
-		Attack:                sql.NullString{String: attack, Valid: true},
-		Evidence:              sql.NullString{String: evidence, Valid: true},
-		OtherInfo:             sql.NullString{String: otherInfo, Valid: true},
+		Uri:                   sql.NullString{String: instance.URI, Valid: instance.URI != ""},
+		Method:                sql.NullString{String: string(instance.Method), Valid: instance.Method != ""},
+		Param:                 sql.NullString{String: instance.Param, Valid: instance.Param != ""},
+		Attack:                sql.NullString{String: instance.Attack, Valid: instance.Attack != ""},
+		Evidence:              sql.NullString{String: instance.Evidence, Valid: instance.Evidence != ""},
+		OtherInfo:             sql.NullString{String: instance.OtherInfo, Valid: instance.OtherInfo != ""},
 	}
 	_, err := queries.CreateWebVulnerabilityInstance(ctx, params)
 	return err

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -91,7 +91,6 @@ func (r *VulnerRepo) CreateVulnerabilityFromWebVuln(
 		VulnSource:     "OWASP ZAP",
 		VulnType:       repository.VulnerabilityTypeEnumWEBAPPLICATION,
 		AnalystComment: sql.NullString{String: "", Valid: false},
-		WascID:         sql.NullString{String: vuln.WascID, Valid: len(vuln.WascID) > 0},
 	}
 	dbVulner, err := query.CreateVulnerability(ctx, params)
 	if err != nil {
@@ -1128,7 +1127,7 @@ func buildSeverityWhereClause(severityFilters []string, queryParams []any) (stri
 	return severityWhereClause, queryParams
 }
 
-func (r *VulnerRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string) (*domain.WebVulnerability, error) {
+func (r *VulnerRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID, hostID uuid.UUID, serviceID int32, solution, reference string, wascID *string) (*domain.WebVulnerability, error) {
 	queries := r.getQueries(ctx)
 	params := repository.CreateWebVulnerabilityParams{
 		VulnerabilityID: vulnID,
@@ -1137,6 +1136,9 @@ func (r *VulnerRepo) CreateWebVulnerability(ctx context.Context, vulnID, scanID,
 		ServiceID:       serviceID,
 		SolutionAdvice:  sql.NullString{String: solution, Valid: true},
 		Reference:       sql.NullString{String: reference, Valid: true},
+	}
+	if wascID != nil {
+		params.WascID = sql.NullString{String: *wascID, Valid: true}
 	}
 	dbWebVuln, err := queries.CreateWebVulnerability(ctx, params)
 	if err != nil {
@@ -1155,16 +1157,7 @@ func (r *VulnerRepo) GetWebVulnerabilityByID(ctx context.Context, vulnID uuid.UU
 		}
 	}
 
-	domNetOSVuln := domain.WebVulnerability{
-		VulnerabilityID: webVuln.VulnerabilityID,
-		ScanID:          webVuln.ScanID,
-		HostID:          webVuln.HostID,
-		ServiceID:       webVuln.ServiceID,
-		SolutionAdvice:  webVuln.SolutionAdvice.String,
-		Reference:       webVuln.Reference.String,
-		CreatedAt:       &webVuln.CreatedAt.Time,
-		UpdatedAt:       &webVuln.UpdatedAt.Time,
-	}
+	domNetOSVuln := r.fromDBtoDomainWebVuln(webVuln)
 	return &domNetOSVuln, nil
 }
 
@@ -1184,6 +1177,10 @@ func (r *VulnerRepo) ListWebVulnerabilitiesByScanID(ctx context.Context, scanID 
 }
 
 func (r *VulnerRepo) fromDBtoDomainWebVuln(dbVuln repository.WebVulnerability) domain.WebVulnerability {
+	var wascID *string
+	if dbVuln.WascID.Valid {
+		wascID = &dbVuln.WascID.String
+	}
 	return domain.WebVulnerability{
 		VulnerabilityID: dbVuln.VulnerabilityID,
 		ScanID:          dbVuln.ScanID,
@@ -1191,6 +1188,7 @@ func (r *VulnerRepo) fromDBtoDomainWebVuln(dbVuln repository.WebVulnerability) d
 		ServiceID:       dbVuln.ServiceID,
 		SolutionAdvice:  dbVuln.SolutionAdvice.String,
 		Reference:       dbVuln.Reference.String,
+		WascID:          wascID,
 		CreatedAt:       &dbVuln.CreatedAt.Time,
 		UpdatedAt:       &dbVuln.UpdatedAt.Time,
 	}


### PR DESCRIPTION
This PR refactors our database schema to correctly follow our established "class table inheritance" pattern. The wasc_id field, which is specific to web vulnerabilities, has been moved from the generic vulnerabilities table to the specialized web_vulnerabilities table.

This change touches database migrations, sqlc queries, and Go models to ensure the entire data flow is consistent with the new, cleaner schema.

## 🤔 Why It's Important

* **Architectural Consistency:** Aligns our database with the design principles outlined in our ADRs, making the schema more logical and easier to understand.

* **Data Integrity:** Ensures that only web-specific vulnerabilities can have a wasc_id, preventing data inconsistencies.

* **Maintainability:** Simplifies the parent vulnerabilities table, making future modifications cleaner.

***


### **✨ Key Changes**

#### **🐘 Database & Migrations**
* A new migration (`000029_...`) has been created to handle the schema change.
* The `wasc_id` column has been **removed** from the `vulnerabilities` table.
* The `wasc_id` column has been **added** to the `web_vulnerabilities` table.

#### **📝 Queries & Models**
* The `sqlc`-generated models (`Vulnerability` and `WebVulnerability`) have been updated to reflect the new location of `wasc_id`.
* All `sqlc` queries (`INSERT`, `SELECT`, etc.) have been modified to reference `wasc_id` in the correct table (`web_vulnerabilities`).