### PR TITLE
Story/kt 537 refactor simplify

### DIFF
--- a/bruno/core-service/Login with Core-Service.bru
+++ b/bruno/core-service/Login with Core-Service.bru
@@ -16,8 +16,16 @@ headers {
 
 body:json {
   {
-    "loginId": "lucasgrez3010@gmail.com",
+    "loginId": "jlozano@uni.edu.pe",
     "password": "password",
     "application_id": "00000000-1111-0000-0000-000000000000"
   }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  
+  const token = jsonData.token;
+  
+  bru.setEnvVar("auth_token", token);
 }

--- a/bruno/core-service/Register Host.bru
+++ b/bruno/core-service/Register Host.bru
@@ -16,8 +16,8 @@ auth:bearer {
 
 body:json {
   {
-    "value": "nmap.scanme.org",
-    "name": "Nmap Scanme",
+    "value": "http://www.susaron.cl",
+    "name": "Susarons",
     "value_type": "Domain",
     "credentials": [
       {
@@ -33,4 +33,12 @@ body:json {
       }
     ]
   }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  
+  const hostID = jsonData.id;
+  
+  bru.setEnvVar("hostID", hostID);
 }

--- a/bruno/core-service/environments/kptm-tools.bru
+++ b/bruno/core-service/environments/kptm-tools.bru
@@ -1,8 +1,10 @@
 vars {
-  auth_token: 
-  OTP: 
-  hostID: 
-  scanID: 
-  vulnerability_id: 
-  serviceID: 
+  hostID: a8eca4c8-2373-4f6b-9dbd-7b56c7284021
+  scanID: 1699155c-6e12-4fc8-8995-74a5ec2e74b8
+  vulnerability_id: 54da11ae-b567-473c-9cb2-a22f18237b15
+  serviceID: 59
 }
+vars:secret [
+  OTP,
+  auth_token
+]

--- a/cmd/test-cwe/main.go
+++ b/cmd/test-cwe/main.go
@@ -12,9 +12,46 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/kptm-tools/core-service/pkg/services"
 )
+
+// findProjectRoot attempts to find the project root directory
+func findProjectRoot() (string, error) {
+	// Get the path of the current source file
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("failed to get current file path")
+	}
+
+	// Navigate up from cmd/test-cwe/main.go to find project root
+	dir := filepath.Dir(filename)
+	
+	// Try different levels to find go.mod (indicator of project root)
+	for i := 0; i < 5; i++ {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return dir, nil
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	// If go.mod not found, fall back to relative paths from current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	
+	// Check if we're already in the project root
+	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
+		return cwd, nil
+	}
+	
+	return "", fmt.Errorf("could not find project root")
+}
 
 func main() {
 	fmt.Println("CWE Parsing Validation Tool")
@@ -22,9 +59,29 @@ func main() {
 
 	parser := services.NewCWEParser()
 
+	// Find project root first
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		fmt.Printf("⚠️ Could not determine project root, using relative paths: %v\n", err)
+		projectRoot = "."
+	}
+
+	// Construct path to CWE JSON file
+	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
+	
+	// Check if file exists
+	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
+		// Try current working directory as fallback
+		cweFilePath = "data/cwe.json"
+		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
+			log.Fatalf("❌ CWE JSON file not found at %s or %s", 
+				filepath.Join(projectRoot, "data", "cwe.json"), cweFilePath)
+		}
+	}
+
 	// Test parsing the CWE JSON file
-	fmt.Println("Loading and parsing data/cwe.json...")
-	cweData, err := parser.LoadCWE("data/cwe.json")
+	fmt.Printf("Loading and parsing %s...\n", cweFilePath)
+	cweData, err := parser.LoadCWE(cweFilePath)
 	if err != nil {
 		log.Fatalf("❌ Failed to parse CWE data: %v", err)
 	}

--- a/cmd/test-cwe/main.go
+++ b/cmd/test-cwe/main.go
@@ -14,44 +14,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/kptm-tools/core-service/pkg/services"
+	"github.com/kptm-tools/core-service/pkg/utils"
 )
-
-// findProjectRoot attempts to find the project root directory
-func findProjectRoot() (string, error) {
-	// Get the path of the current source file
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", fmt.Errorf("failed to get current file path")
-	}
-
-	// Navigate up from cmd/test-cwe/main.go to find project root
-	dir := filepath.Dir(filename)
-	
-	// Try different levels to find go.mod (indicator of project root)
-	for i := 0; i < 5; i++ {
-		goModPath := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(goModPath); err == nil {
-			return dir, nil
-		}
-		dir = filepath.Dir(dir)
-	}
-
-	// If go.mod not found, fall back to relative paths from current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-	
-	// Check if we're already in the project root
-	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
-		return cwd, nil
-	}
-	
-	return "", fmt.Errorf("could not find project root")
-}
 
 func main() {
 	fmt.Println("CWE Parsing Validation Tool")
@@ -60,7 +26,7 @@ func main() {
 	parser := services.NewCWEParser()
 
 	// Find project root first
-	projectRoot, err := findProjectRoot()
+	projectRoot, err := utils.FindProjectRoot()
 	if err != nil {
 		fmt.Printf("⚠️ Could not determine project root, using relative paths: %v\n", err)
 		projectRoot = "."
@@ -68,13 +34,13 @@ func main() {
 
 	// Construct path to CWE JSON file
 	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
-	
+
 	// Check if file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
 		// Try current working directory as fallback
 		cweFilePath = "data/cwe.json"
 		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-			log.Fatalf("❌ CWE JSON file not found at %s or %s", 
+			log.Fatalf("❌ CWE JSON file not found at %s or %s",
 				filepath.Join(projectRoot, "data", "cwe.json"), cweFilePath)
 		}
 	}

--- a/db/cwe_detail.sql.go
+++ b/db/cwe_detail.sql.go
@@ -51,6 +51,25 @@ func (q *Queries) CreateOrUpdateCWEDetail(ctx context.Context, arg CreateOrUpdat
 	return i, err
 }
 
+const getCWEDetailByCWEID = `-- name: GetCWEDetailByCWEID :one
+SELECT cwe_id, title, description, last_updated, created_at
+FROM cwe_details
+WHERE cwe_id = $1
+`
+
+func (q *Queries) GetCWEDetailByCWEID(ctx context.Context, cweID string) (CweDetail, error) {
+	row := q.db.QueryRowContext(ctx, getCWEDetailByCWEID, cweID)
+	var i CweDetail
+	err := row.Scan(
+		&i.CweID,
+		&i.Title,
+		&i.Description,
+		&i.LastUpdated,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getCWEDetailWithMitigationsByID = `-- name: GetCWEDetailWithMitigationsByID :many
 SELECT
   cd.cwe_id,

--- a/db/db_tool/main.go
+++ b/db/db_tool/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/kptm-tools/core-service/pkg/config"
 	"github.com/kptm-tools/core-service/pkg/services"
 	"github.com/kptm-tools/core-service/pkg/storage"
+	"github.com/kptm-tools/core-service/pkg/utils"
 	_ "github.com/lib/pq"
 	"github.com/lmittmann/tint"
 )
@@ -210,47 +210,13 @@ func createMigration() {
 	logger.Info("Migration created successfully", slog.String("name", name))
 }
 
-// findProjectRoot attempts to find the project root directory
-func findProjectRoot() (string, error) {
-	// Get the path of the current source file
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", fmt.Errorf("failed to get current file path")
-	}
-
-	// Navigate up from db/db_tool/main.go to find project root
-	dir := filepath.Dir(filename)
-	
-	// Try different levels to find go.mod (indicator of project root)
-	for i := 0; i < 5; i++ {
-		goModPath := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(goModPath); err == nil {
-			return dir, nil
-		}
-		dir = filepath.Dir(dir)
-	}
-
-	// If go.mod not found, fall back to relative paths from current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-	
-	// Check if we're already in the project root
-	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
-		return cwd, nil
-	}
-	
-	return "", fmt.Errorf("could not find project root")
-}
-
 func populateCWE() {
 	ctx := context.Background()
 
 	logger.Info("Starting CWE population process...")
 
 	// Find project root first
-	projectRoot, err := findProjectRoot()
+	projectRoot, err := utils.FindProjectRoot()
 	if err != nil {
 		logger.Warn("Could not determine project root, using relative paths", slog.Any("error", err))
 		projectRoot = "."
@@ -258,13 +224,13 @@ func populateCWE() {
 
 	// Construct path to CWE JSON file
 	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
-	
+
 	// Check if file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
 		// Try current working directory as fallback
 		cweFilePath = "data/cwe.json"
 		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-			logger.Error("CWE JSON file not found", 
+			logger.Error("CWE JSON file not found",
 				slog.String("expected_path", filepath.Join(projectRoot, "data", "cwe.json")),
 				slog.String("fallback_path", "data/cwe.json"))
 			os.Exit(1)

--- a/db/db_tool/main.go
+++ b/db/db_tool/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -209,20 +210,63 @@ func createMigration() {
 	logger.Info("Migration created successfully", slog.String("name", name))
 }
 
+// findProjectRoot attempts to find the project root directory
+func findProjectRoot() (string, error) {
+	// Get the path of the current source file
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("failed to get current file path")
+	}
+
+	// Navigate up from db/db_tool/main.go to find project root
+	dir := filepath.Dir(filename)
+	
+	// Try different levels to find go.mod (indicator of project root)
+	for i := 0; i < 5; i++ {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return dir, nil
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	// If go.mod not found, fall back to relative paths from current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	
+	// Check if we're already in the project root
+	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
+		return cwd, nil
+	}
+	
+	return "", fmt.Errorf("could not find project root")
+}
+
 func populateCWE() {
 	ctx := context.Background()
 
 	logger.Info("Starting CWE population process...")
 
-	// Find the CWE JSON file
-	cweFilePath := "data/cwe.json"
+	// Find project root first
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		logger.Warn("Could not determine project root, using relative paths", slog.Any("error", err))
+		projectRoot = "."
+	}
 
-	// Check if running from core-service directory
+	// Construct path to CWE JSON file
+	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
+	
+	// Check if file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-		// Try from project root
-		cweFilePath = filepath.Join("..", "..", "data", "cwe.json")
+		// Try current working directory as fallback
+		cweFilePath = "data/cwe.json"
 		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-			logger.Error("CWE JSON file not found. Expected at data/cwe.json or ../../data/cwe.json")
+			logger.Error("CWE JSON file not found", 
+				slog.String("expected_path", filepath.Join(projectRoot, "data", "cwe.json")),
+				slog.String("fallback_path", "data/cwe.json"))
 			os.Exit(1)
 		}
 	}

--- a/db/sampledata/main.go
+++ b/db/sampledata/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	migrations "github.com/kptm-tools/core-service/db/sql"
@@ -17,6 +16,7 @@ import (
 	"github.com/kptm-tools/core-service/pkg/samples"
 	"github.com/kptm-tools/core-service/pkg/services"
 	"github.com/kptm-tools/core-service/pkg/storage"
+	"github.com/kptm-tools/core-service/pkg/utils"
 )
 
 type PopulatorDependencies struct {
@@ -105,44 +105,10 @@ func populateDB(ctx context.Context, deps PopulatorDependencies) {
 	fmt.Println("🎉 Database population completed successfully!")
 }
 
-// findProjectRoot attempts to find the project root directory
-func findProjectRoot() (string, error) {
-	// Get the path of the current source file
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", fmt.Errorf("failed to get current file path")
-	}
-
-	// Navigate up from db/sampledata/main.go to find project root
-	dir := filepath.Dir(filename)
-	
-	// Try different levels to find go.mod (indicator of project root)
-	for i := 0; i < 5; i++ {
-		goModPath := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(goModPath); err == nil {
-			return dir, nil
-		}
-		dir = filepath.Dir(dir)
-	}
-
-	// If go.mod not found, fall back to relative paths from current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-	
-	// Check if we're already in the project root
-	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
-		return cwd, nil
-	}
-	
-	return "", fmt.Errorf("could not find project root")
-}
-
 // populateCWEKnowledgeBase executes the CWE pre-population script
 func populateCWEKnowledgeBase() error {
 	// Find project root first
-	projectRoot, err := findProjectRoot()
+	projectRoot, err := utils.FindProjectRoot()
 	if err != nil {
 		// Fall back to current directory
 		projectRoot = "."
@@ -150,13 +116,13 @@ func populateCWEKnowledgeBase() error {
 
 	// Construct path to CWE JSON file
 	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
-	
+
 	// Verify the CWE file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
 		// Try relative path as fallback
 		cweFilePath = "data/cwe.json"
 		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-			return fmt.Errorf("CWE JSON file not found at %s or %s", 
+			return fmt.Errorf("CWE JSON file not found at %s or %s",
 				filepath.Join(projectRoot, "data", "cwe.json"), cweFilePath)
 		}
 	}

--- a/db/sampledata/main.go
+++ b/db/sampledata/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"math/rand"
+	"os/exec"
+
 	"github.com/kptm-tools/common/common/pkg/enums"
-	"github.com/kptm-tools/common/common/pkg/results/tools"
 	migrations "github.com/kptm-tools/core-service/db/sql"
 	"github.com/kptm-tools/core-service/pkg/config"
 	"github.com/kptm-tools/core-service/pkg/domain"
@@ -12,8 +15,6 @@ import (
 	"github.com/kptm-tools/core-service/pkg/samples"
 	"github.com/kptm-tools/core-service/pkg/services"
 	"github.com/kptm-tools/core-service/pkg/storage"
-	"math/rand"
-	"os"
 )
 
 type PopulatorDependencies struct {
@@ -67,25 +68,61 @@ func Run() {
 }
 
 func populateDB(ctx context.Context, deps PopulatorDependencies) {
-	fmt.Println("Populating DB with sample data...")
+	fmt.Println("Starting comprehensive database population...")
 
+	// Step 1: Pre-populate CWE knowledge base first
+	fmt.Println("Step 1/4: Pre-populating CWE knowledge base...")
+	if err := populateCWEKnowledgeBase(); err != nil {
+		panic(fmt.Errorf("failed to populate CWE knowledge base: %w", err))
+	}
+	fmt.Println("✅ CWE knowledge base populated successfully")
+
+	// Step 2: Populate tenants
+	fmt.Println("Step 2/4: Populating tenants...")
 	tenants, err := populateTenants()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Tenants populated successfully")
+	fmt.Println("✅ Tenants populated successfully")
 
+	// Step 3: Populate hosts
+	fmt.Println("Step 3/4: Populating hosts...")
 	hosts, errHost := populateHosts(ctx, deps.HostRepo, tenants)
 	if errHost != nil {
 		panic(errHost)
 	}
-	fmt.Println("Hosts populated successfully")
+	fmt.Println("✅ Hosts populated successfully")
 
-	fmt.Println("Populating scans...")
+	// Step 4: Populate scans with realistic vulnerability data
+	fmt.Println("Step 4/4: Populating scans with realistic vulnerability data...")
 	if err := populateScans(ctx, deps, tenants, hosts); err != nil {
 		panic(err)
 	}
-	fmt.Println("Scans populated successfully")
+	fmt.Println("✅ Scans populated successfully")
+	
+	fmt.Println("🎉 Database population completed successfully!")
+}
+
+// populateCWEKnowledgeBase executes the CWE pre-population script
+func populateCWEKnowledgeBase() error {
+	// Find the CWE JSON file (command runs from project root)
+	cweFilePath := "data/cwe.json"
+	
+	// Verify the CWE file exists
+	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
+		return fmt.Errorf("CWE JSON file not found at %s", cweFilePath)
+	}
+
+	// Execute the CWE population command using db_tool
+	cmd := exec.Command("go", "run", "./db/db_tool/main.go", "populate-cwe")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute CWE population: %w", err)
+	}
+
+	return nil
 }
 
 func populateTenants() ([]domain.Tenant, error) {
@@ -128,8 +165,7 @@ func populateScans(
 		sampleScans[i] = *createdScan
 	}
 
-	cweDetails := samples.SampleCWEDetails()
-	if err := populateNetworkOSVulnerabilities(ctx, deps, sampleScans, cweDetails); err != nil {
+	if err := populateNetworkOSVulnerabilities(ctx, deps, sampleScans); err != nil {
 		return fmt.Errorf("error populating NetworkOSVulnerabilities: %w", err)
 	}
 
@@ -163,10 +199,9 @@ func populateNetworkOSVulnerabilities(
 	ctx context.Context,
 	deps PopulatorDependencies,
 	scans []domain.Scan,
-	cweDetails []tools.CWERemediation,
 ) error {
 	for _, scan := range scans {
-		sampleNmapResult := samples.SampleNmapScanResults(scan, cweDetails)
+		sampleNmapResult := samples.SampleNmapScanResults(scan)
 		err := deps.VulnerabilityService.CreateNetworkOSVulnerabilities(ctx, scan.ID, sampleNmapResult)
 		if err != nil {
 			return fmt.Errorf("failed to create networkOSVulnerability: %w", err)

--- a/db/sampledata/main.go
+++ b/db/sampledata/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"math/rand"
+	"os"
 	"os/exec"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
@@ -99,7 +99,7 @@ func populateDB(ctx context.Context, deps PopulatorDependencies) {
 		panic(err)
 	}
 	fmt.Println("✅ Scans populated successfully")
-	
+
 	fmt.Println("🎉 Database population completed successfully!")
 }
 
@@ -107,7 +107,7 @@ func populateDB(ctx context.Context, deps PopulatorDependencies) {
 func populateCWEKnowledgeBase() error {
 	// Find the CWE JSON file (command runs from project root)
 	cweFilePath := "data/cwe.json"
-	
+
 	// Verify the CWE file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("CWE JSON file not found at %s", cweFilePath)
@@ -117,7 +117,7 @@ func populateCWEKnowledgeBase() error {
 	cmd := exec.Command("go", "run", "./db/db_tool/main.go", "populate-cwe")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	
+
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to execute CWE population: %w", err)
 	}

--- a/db/sampledata/main.go
+++ b/db/sampledata/main.go
@@ -6,6 +6,8 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"github.com/kptm-tools/common/common/pkg/enums"
 	migrations "github.com/kptm-tools/core-service/db/sql"
@@ -103,18 +105,66 @@ func populateDB(ctx context.Context, deps PopulatorDependencies) {
 	fmt.Println("🎉 Database population completed successfully!")
 }
 
+// findProjectRoot attempts to find the project root directory
+func findProjectRoot() (string, error) {
+	// Get the path of the current source file
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("failed to get current file path")
+	}
+
+	// Navigate up from db/sampledata/main.go to find project root
+	dir := filepath.Dir(filename)
+	
+	// Try different levels to find go.mod (indicator of project root)
+	for i := 0; i < 5; i++ {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return dir, nil
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	// If go.mod not found, fall back to relative paths from current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	
+	// Check if we're already in the project root
+	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
+		return cwd, nil
+	}
+	
+	return "", fmt.Errorf("could not find project root")
+}
+
 // populateCWEKnowledgeBase executes the CWE pre-population script
 func populateCWEKnowledgeBase() error {
-	// Find the CWE JSON file (command runs from project root)
-	cweFilePath := "data/cwe.json"
+	// Find project root first
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		// Fall back to current directory
+		projectRoot = "."
+	}
 
+	// Construct path to CWE JSON file
+	cweFilePath := filepath.Join(projectRoot, "data", "cwe.json")
+	
 	// Verify the CWE file exists
 	if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
-		return fmt.Errorf("CWE JSON file not found at %s", cweFilePath)
+		// Try relative path as fallback
+		cweFilePath = "data/cwe.json"
+		if _, err := os.Stat(cweFilePath); os.IsNotExist(err) {
+			return fmt.Errorf("CWE JSON file not found at %s or %s", 
+				filepath.Join(projectRoot, "data", "cwe.json"), cweFilePath)
+		}
 	}
 
 	// Execute the CWE population command using db_tool
+	// Change to project root directory to ensure db_tool runs from correct location
 	cmd := exec.Command("go", "run", "./db/db_tool/main.go", "populate-cwe")
+	cmd.Dir = projectRoot
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/db/sql/queries/cwe_detail.sql
+++ b/db/sql/queries/cwe_detail.sql
@@ -12,6 +12,11 @@ INSERT INTO cwe_details (
   last_updated = EXCLUDED.last_updated
 RETURNING *;
 
+-- name: GetCWEDetailByCWEID :one
+SELECT cwe_id, title, description, last_updated, created_at
+FROM cwe_details
+WHERE cwe_id = $1;
+
 -- name: GetCWEDetailWithMitigationsByID :many 
 SELECT
   cd.cwe_id,

--- a/docs/adr/ADR-004.md
+++ b/docs/adr/ADR-004.md
@@ -1,4 +1,4 @@
-# ADR-002: Decouple CWE Knowledge Base from Event Stream
+# ADR-004: Decouple CWE Knowledge Base from Event Stream
 
 **Status:** Accepted
 **Date:** 2025-08-01
@@ -8,11 +8,13 @@
 Our system processes vulnerability data from various producer services (e.g., `vulnerability-analysis`). A key piece of data for each vulnerability is its associated Common Weakness Enumeration (CWE) details, including potential remediations.
 
 The previous architecture handled this enrichment process in real-time:
-1.  The producer service (`vulnerability-analysis`) embedded a large `cwe.json` file containing a comprehensive knowledge base from MITRE.
-2.  Upon finding a vulnerability, the producer would search this in-memory data and **enrich the event payload** with all relevant CWE details and remediation steps.
-3.  The consumer service (`core-service`) would then receive this large payload and perform an "upsert" operation into the `cwe_details` and `cwe_remediations` tables for every single vulnerability processed.
+
+1. The producer service (`vulnerability-analysis`) embedded a large `cwe.json` file containing a comprehensive knowledge base from MITRE.
+2. Upon finding a vulnerability, the producer would search this in-memory data and **enrich the event payload** with all relevant CWE details and remediation steps.
+3. The consumer service (`core-service`) would then receive this large payload and perform an "upsert" operation into the `cwe_details` and `cwe_remediations` tables for every single vulnerability processed.
 
 This approach led to significant architectural problems:
+
 * **Performance Bottleneck:** The consumer was constantly performing database writes for highly redundant, static data, creating a major bottleneck during vulnerability ingestion.
 * **Excessive Payload Size:** Event payloads were unnecessarily bloated with static knowledge base information, increasing network traffic and message bus load.
 * **Tight Coupling:** The consumer's logic was tightly coupled to the data enrichment process of the producer.
@@ -23,23 +25,23 @@ We needed a more efficient and decoupled architecture for managing this static C
 
 We have decided to refactor the system to treat the CWE data as a **pre-populated, static knowledge base** within the database. The responsibility for data enrichment is shifted from the real-time event stream to the data access layer at read-time.
 
-1.  **Pre-populate the Knowledge Base:** A dedicated, command-line script (e.g., `cmd/db-tool`) will be created in the `core-service`. This script will be responsible for parsing the `cwe.json` file and performing a one-time "upsert" of all data into the `cwe_details` and `cwe_remediations` tables. This script will be run during initial environment setup or whenever the CWE data needs to be updated.
+1. **Pre-populate the Knowledge Base:** A dedicated, command-line script (e.g., `cmd/db-tool`) will be created in the `core-service`. This script will be responsible for parsing the `cwe.json` file and performing a one-time "upsert" of all data into the `cwe_details` and `cwe_remediations` tables. This script will be run during initial environment setup or whenever the CWE data needs to be updated.
 
-2.  **Simplify Event Payloads:** Producer services will no longer enrich event payloads with full CWE details. They will only be responsible for providing the standardized `cwe_id` string (e.g., "CWE-79") for each vulnerability.
+2. **Simplify Event Payloads:** Producer services will no longer enrich event payloads with full CWE details. They will only be responsible for providing the standardized `cwe_id` string (e.g., "CWE-79") for each vulnerability.
 
-3.  **Handle Unknown CWEs Gracefully:** If the consumer receives a vulnerability with a `cwe_id` that is not present in the `cwe_details` table, the service logic will **auto-create a minimal "stub" record** for that CWE ID. This ensures the foreign key constraint on the `vulnerabilities` table is always satisfied and prevents ingestion failures, while allowing us to enrich the stub record later.
+3. **Handle Unknown CWEs Gracefully:** If the consumer receives a vulnerability with a `cwe_id` that is not present in the `cwe_details` table, the service logic will **auto-create a minimal "stub" record** for that CWE ID. This ensures the foreign key constraint on the `vulnerabilities` table is always satisfied and prevents ingestion failures, while allowing us to enrich the stub record later.
 
 ## ➡️ Consequences
 
 ### ✅ Positive
 
--   **Improved Performance:** The vulnerability ingestion process will be drastically faster, as the consumer no longer performs thousands of redundant database upserts for static data.
--   **Reduced System Load:** Event payloads will be significantly smaller, reducing network traffic and the load on our NATS messaging system.
--   **Decoupled Architecture:** The producer is now only responsible for identifying vulnerabilities, and the consumer is only responsible for recording them. The CWE knowledge base is managed independently.
--   **Centralized Data:** All CWE information resides within the database, providing a single source of truth for the entire platform.
+* **Improved Performance:** The vulnerability ingestion process will be drastically faster, as the consumer no longer performs thousands of redundant database upserts for static data.
+* **Reduced System Load:** Event payloads will be significantly smaller, reducing network traffic and the load on our NATS messaging system.
+* **Decoupled Architecture:** The producer is now only responsible for identifying vulnerabilities, and the consumer is only responsible for recording them. The CWE knowledge base is managed independently.
+* **Centralized Data:** All CWE information resides within the database, providing a single source of truth for the entire platform.
 
 ### ❌ Negative
 
--   **New Operational Step:** Setting up a new development environment or updating the CWE data now requires an explicit, manual step: running the pre-population script. This needs to be clearly documented.
--   **Potential for Stale Data:** If the `cwe.json` file is updated in the producer, the pre-population script must be re-run to update the database. There is a risk of a delay between the data source update and the database update.
--   **Stub Records:** The database may contain incomplete "stub" records for new or unknown CWEs, which will require a separate process to monitor and enrich over time.
+* **New Operational Step:** Setting up a new development environment or updating the CWE data now requires an explicit, manual step: running the pre-population script. This needs to be clearly documented.
+* **Potential for Stale Data:** If the `cwe.json` file is updated in the producer, the pre-population script must be re-run to update the database. There is a risk of a delay between the data source update and the database update.
+* **Stub Records:** The database may contain incomplete "stub" records for new or unknown CWEs, which will require a separate process to monitor and enrich over time.

--- a/docs/adr/ADR-004.md
+++ b/docs/adr/ADR-004.md
@@ -1,0 +1,45 @@
+# ADR-002: Decouple CWE Knowledge Base from Event Stream
+
+**Status:** Accepted
+**Date:** 2025-08-01
+
+## 💭 Context
+
+Our system processes vulnerability data from various producer services (e.g., `vulnerability-analysis`). A key piece of data for each vulnerability is its associated Common Weakness Enumeration (CWE) details, including potential remediations.
+
+The previous architecture handled this enrichment process in real-time:
+1.  The producer service (`vulnerability-analysis`) embedded a large `cwe.json` file containing a comprehensive knowledge base from MITRE.
+2.  Upon finding a vulnerability, the producer would search this in-memory data and **enrich the event payload** with all relevant CWE details and remediation steps.
+3.  The consumer service (`core-service`) would then receive this large payload and perform an "upsert" operation into the `cwe_details` and `cwe_remediations` tables for every single vulnerability processed.
+
+This approach led to significant architectural problems:
+* **Performance Bottleneck:** The consumer was constantly performing database writes for highly redundant, static data, creating a major bottleneck during vulnerability ingestion.
+* **Excessive Payload Size:** Event payloads were unnecessarily bloated with static knowledge base information, increasing network traffic and message bus load.
+* **Tight Coupling:** The consumer's logic was tightly coupled to the data enrichment process of the producer.
+
+We needed a more efficient and decoupled architecture for managing this static CWE data.
+
+## 💪 Decision
+
+We have decided to refactor the system to treat the CWE data as a **pre-populated, static knowledge base** within the database. The responsibility for data enrichment is shifted from the real-time event stream to the data access layer at read-time.
+
+1.  **Pre-populate the Knowledge Base:** A dedicated, command-line script (e.g., `cmd/db-tool`) will be created in the `core-service`. This script will be responsible for parsing the `cwe.json` file and performing a one-time "upsert" of all data into the `cwe_details` and `cwe_remediations` tables. This script will be run during initial environment setup or whenever the CWE data needs to be updated.
+
+2.  **Simplify Event Payloads:** Producer services will no longer enrich event payloads with full CWE details. They will only be responsible for providing the standardized `cwe_id` string (e.g., "CWE-79") for each vulnerability.
+
+3.  **Handle Unknown CWEs Gracefully:** If the consumer receives a vulnerability with a `cwe_id` that is not present in the `cwe_details` table, the service logic will **auto-create a minimal "stub" record** for that CWE ID. This ensures the foreign key constraint on the `vulnerabilities` table is always satisfied and prevents ingestion failures, while allowing us to enrich the stub record later.
+
+## ➡️ Consequences
+
+### ✅ Positive
+
+-   **Improved Performance:** The vulnerability ingestion process will be drastically faster, as the consumer no longer performs thousands of redundant database upserts for static data.
+-   **Reduced System Load:** Event payloads will be significantly smaller, reducing network traffic and the load on our NATS messaging system.
+-   **Decoupled Architecture:** The producer is now only responsible for identifying vulnerabilities, and the consumer is only responsible for recording them. The CWE knowledge base is managed independently.
+-   **Centralized Data:** All CWE information resides within the database, providing a single source of truth for the entire platform.
+
+### ❌ Negative
+
+-   **New Operational Step:** Setting up a new development environment or updating the CWE data now requires an explicit, manual step: running the pre-population script. This needs to be clearly documented.
+-   **Potential for Stale Data:** If the `cwe.json` file is updated in the producer, the pre-population script must be re-run to update the database. There is a risk of a delay between the data source update and the database update.
+-   **Stub Records:** The database may contain incomplete "stub" records for new or unknown CWEs, which will require a separate process to monitor and enrich over time.

--- a/pkg/domain/cwe.go
+++ b/pkg/domain/cwe.go
@@ -2,14 +2,43 @@ package domain
 
 import "time"
 
+// CWEDetailWithMitigations represents a CWE weakness with its associated mitigation strategies.
+// This struct is used for read operations that join cwe_details and cwe_mitigations tables.
+// It assumes CWE data is pre-populated in the database and should not be created on-the-fly.
 type CWEDetailWithMitigations struct {
+	// CWE Detail fields (from cwe_details table)
+	CweID       string    `json:"cwe_id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	LastUpdated time.Time `json:"last_updated"`
+
+	// Mitigation fields (from cwe_mitigations table)
+	MitigationID          string    `json:"mitigation_id,omitempty"`
+	Phase                 string    `json:"phase,omitempty"`
+	MitigationDescription string    `json:"mitigation_description,omitempty"`
+	Effectiveness         string    `json:"effectiveness,omitempty"`
+	EffectivenessNotes    string    `json:"effectiveness_notes,omitempty"`
+	MitigationCreatedAt   time.Time `json:"mitigation_created_at,omitempty"`
+}
+
+// CWEDetail represents a CWE weakness without mitigations.
+// This is used when only the basic CWE information is needed.
+// Maintains backward compatibility with existing code.
+type CWEDetail struct {
+	ID          string     `json:"cwe_id"`          // Renamed from CweID for backward compatibility
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	CreatedAt   *time.Time `json:"created_at"`      // Maintained for backward compatibility
+	LastUpdated *time.Time `json:"last_updated"`    // Maintained for backward compatibility
+}
+
+// CWEMitigation represents a single mitigation strategy for a CWE.
+type CWEMitigation struct {
 	CweID                 string    `json:"cwe_id"`
-	Title                 string    `json:"title"`
-	Description           string    `json:"description"`
 	MitigationID          string    `json:"mitigation_id"`
 	Phase                 string    `json:"phase"`
 	MitigationDescription string    `json:"mitigation_description"`
-	Effectiveness         string    `json:"effectiveness"`
-	EffectivenessNotes    string    `json:"effectiveness_notes"`
-	MigrationCreatedAt    time.Time `json:"migration_created_at"`
+	Effectiveness         string    `json:"effectiveness,omitempty"`
+	EffectivenessNotes    string    `json:"effectiveness_notes,omitempty"`
+	CreatedAt             time.Time `json:"created_at"`
 }

--- a/pkg/domain/cwe.go
+++ b/pkg/domain/cwe.go
@@ -25,11 +25,11 @@ type CWEDetailWithMitigations struct {
 // This is used when only the basic CWE information is needed.
 // Maintains backward compatibility with existing code.
 type CWEDetail struct {
-	ID          string     `json:"cwe_id"`          // Renamed from CweID for backward compatibility
+	ID          string     `json:"cwe_id"` // Renamed from CweID for backward compatibility
 	Title       string     `json:"title"`
 	Description string     `json:"description"`
-	CreatedAt   *time.Time `json:"created_at"`      // Maintained for backward compatibility
-	LastUpdated *time.Time `json:"last_updated"`    // Maintained for backward compatibility
+	CreatedAt   *time.Time `json:"created_at"`   // Maintained for backward compatibility
+	LastUpdated *time.Time `json:"last_updated"` // Maintained for backward compatibility
 }
 
 // CWEMitigation represents a single mitigation strategy for a CWE.

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -171,13 +171,7 @@ type WebVulnerabilityInstance struct {
 	Evidence string `json:"evidence"`
 }
 
-type CWEDetail struct {
-	ID          string     `json:"cwe_id"`
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	CreatedAt   *time.Time `json:"created_at"`
-	LastUpdated *time.Time `json:"last_updated"`
-}
+// CWEDetail is now defined in cwe.go to avoid duplication and maintain consistency
 
 // MapZapRiskToSeverity maps a given risk code and confidence level from a ZAP web scan to a CVSS severity type.
 // The function evaluates the risk code and confidence level to determine the appropriate severity:

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/kptm-tools/core-service/pkg/convert"
+	"github.com/kptm-tools/core-service/pkg/utils"
 )
 
 type malformedRequest struct {
@@ -127,7 +127,7 @@ func GetIDInt32(req *http.Request) (int32, error) {
 	if err != nil {
 		return 0, err
 	}
-	return convert.SafeIntToInt32(intID)
+	return utils.SafeIntToInt32(intID)
 }
 
 func GetVerificationIDAndTenantID(req *http.Request) (string, string, error) {

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -82,15 +82,14 @@ type CVERepository interface {
 }
 
 type CWERepository interface {
-	// Legacy methods - to be deprecated after refactoring
-	CreateOrUpdateCWE(context.Context, domain.CWEDetail) (*domain.CWEDetail, error)
-	CreateCWERemediation(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error)
-	GetCWERemediationByID(ctx context.Context, mitigationID string) (*tools.CWERemediation, error)
-	GetCWERemediationsByCWEID(ctx context.Context, cweID string) ([]tools.CWERemediation, error)
-	
-	// New methods for refactored approach
+	// Core methods for refactored approach
 	GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDetail, error)
 	CWEExists(ctx context.Context, cweID string) (bool, error)
 	CreateCWEStub(ctx context.Context, cweID string) (*domain.CWEDetail, error)
 	GetCWEDetailWithMitigationsByID(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error)
+
+	// Legacy methods - kept for CWE pre-population script only
+	CreateCWERemediation(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error)
+	GetCWERemediationByID(ctx context.Context, mitigationID string) (*tools.CWERemediation, error)
+	GetCWERemediationsByCWEID(ctx context.Context, cweID string) ([]tools.CWERemediation, error)
 }

--- a/pkg/interfaces/vulnerability.go
+++ b/pkg/interfaces/vulnerability.go
@@ -82,8 +82,15 @@ type CVERepository interface {
 }
 
 type CWERepository interface {
+	// Legacy methods - to be deprecated after refactoring
 	CreateOrUpdateCWE(context.Context, domain.CWEDetail) (*domain.CWEDetail, error)
 	CreateCWERemediation(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error)
 	GetCWERemediationByID(ctx context.Context, mitigationID string) (*tools.CWERemediation, error)
 	GetCWERemediationsByCWEID(ctx context.Context, cweID string) ([]tools.CWERemediation, error)
+	
+	// New methods for refactored approach
+	GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	CWEExists(ctx context.Context, cweID string) (bool, error)
+	CreateCWEStub(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	GetCWEDetailWithMitigationsByID(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error)
 }

--- a/pkg/mocks/storage/cwe.go
+++ b/pkg/mocks/storage/cwe.go
@@ -11,27 +11,21 @@ import (
 )
 
 type MockCWERepo struct {
-	// Legacy methods
-	MockCreateOrUpdateCWE         func(ctx context.Context, vuln domain.CWEDetail) (*domain.CWEDetail, error)
+	// Core methods for refactored approach
+	MockGetCWEByID                      func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	MockCWEExists                       func(ctx context.Context, cweID string) (bool, error)
+	MockCreateCWEStub                   func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	MockGetCWEDetailWithMitigationsByID func(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error)
+
+	// Legacy methods - kept for CWE pre-population script only
 	MockCreateCWERemediation      func(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error)
 	MockGetCWERemediationByID     func(ctx context.Context, mitigationID string) (*tools.CWERemediation, error)
 	MockGetCWERemediationsByCWEID func(ctx context.Context, cweID string) ([]tools.CWERemediation, error)
-	
-	// New methods for refactored approach
-	MockGetCWEByID                           func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
-	MockCWEExists                            func(ctx context.Context, cweID string) (bool, error)
-	MockCreateCWEStub                        func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
-	MockGetCWEDetailWithMitigationsByID      func(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error)
 }
 
 var _ interfaces.CWERepository = (*MockCWERepo)(nil)
 
-func (m *MockCWERepo) CreateOrUpdateCWE(ctx context.Context, vuln domain.CWEDetail) (*domain.CWEDetail, error) {
-	if m.MockCreateOrUpdateCWE != nil {
-		return m.MockCreateOrUpdateCWE(ctx, vuln)
-	}
-	panic(fmt.Sprintf("MockCWERepo: method CreateOrUpdateCWE called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
-}
+// CreateOrUpdateCWE method removed - no longer needed with pre-populated CWE approach
 
 func (m *MockCWERepo) CreateCWERemediation(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error) {
 	if m.MockCreateCWERemediation != nil {

--- a/pkg/mocks/storage/cwe.go
+++ b/pkg/mocks/storage/cwe.go
@@ -11,10 +11,17 @@ import (
 )
 
 type MockCWERepo struct {
+	// Legacy methods
 	MockCreateOrUpdateCWE         func(ctx context.Context, vuln domain.CWEDetail) (*domain.CWEDetail, error)
 	MockCreateCWERemediation      func(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error)
 	MockGetCWERemediationByID     func(ctx context.Context, mitigationID string) (*tools.CWERemediation, error)
 	MockGetCWERemediationsByCWEID func(ctx context.Context, cweID string) ([]tools.CWERemediation, error)
+	
+	// New methods for refactored approach
+	MockGetCWEByID                           func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	MockCWEExists                            func(ctx context.Context, cweID string) (bool, error)
+	MockCreateCWEStub                        func(ctx context.Context, cweID string) (*domain.CWEDetail, error)
+	MockGetCWEDetailWithMitigationsByID      func(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error)
 }
 
 var _ interfaces.CWERepository = (*MockCWERepo)(nil)
@@ -45,4 +52,34 @@ func (m *MockCWERepo) GetCWERemediationsByCWEID(ctx context.Context, cweID strin
 		return m.MockGetCWERemediationsByCWEID(ctx, cweID)
 	}
 	panic(fmt.Sprintf("MockCWERepo: method GetCWERemediationsByCWEID called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
+}
+
+// New methods for refactored approach
+
+func (m *MockCWERepo) GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
+	if m.MockGetCWEByID != nil {
+		return m.MockGetCWEByID(ctx, cweID)
+	}
+	panic(fmt.Sprintf("MockCWERepo: method GetCWEByID called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
+}
+
+func (m *MockCWERepo) CWEExists(ctx context.Context, cweID string) (bool, error) {
+	if m.MockCWEExists != nil {
+		return m.MockCWEExists(ctx, cweID)
+	}
+	panic(fmt.Sprintf("MockCWERepo: method CWEExists called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
+}
+
+func (m *MockCWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
+	if m.MockCreateCWEStub != nil {
+		return m.MockCreateCWEStub(ctx, cweID)
+	}
+	panic(fmt.Sprintf("MockCWERepo: method CreateCWEStub called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
+}
+
+func (m *MockCWERepo) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID string) ([]domain.CWEDetailWithMitigations, error) {
+	if m.MockGetCWEDetailWithMitigationsByID != nil {
+		return m.MockGetCWEDetailWithMitigationsByID(ctx, cweID)
+	}
+	panic(fmt.Sprintf("MockCWERepo: method GetCWEDetailWithMitigationsByID called but not implemented for test: %s", ctx.Value(testutil.TestNameKey)))
 }

--- a/pkg/samples/cwe.go
+++ b/pkg/samples/cwe.go
@@ -4,31 +4,31 @@ package samples
 // These reference the pre-populated CWE knowledge base and represent what producers would actually send.
 func RealisticCWEIDs() []string {
 	return []string{
-		"CWE-79",   // Cross-site Scripting (XSS)
-		"CWE-89",   // SQL Injection
-		"CWE-22",   // Path Traversal
-		"CWE-352",  // Cross-Site Request Forgery (CSRF)
-		"CWE-434",  // Unrestricted Upload of File with Dangerous Type
-		"CWE-78",   // OS Command Injection
-		"CWE-601",  // URL Redirection to Untrusted Site ('Open Redirect')
-		"CWE-502",  // Deserialization of Untrusted Data
-		"CWE-287",  // Improper Authentication
-		"CWE-862",  // Missing Authorization
-		"CWE-798",  // Use of Hard-coded Credentials
-		"CWE-200",  // Information Exposure
-		"CWE-522",  // Insufficiently Protected Credentials
-		"CWE-319",  // Cleartext Transmission of Sensitive Information
-		"CWE-326",  // Inadequate Encryption Strength
-		"CWE-330",  // Use of Insufficiently Random Values
-		"CWE-16",   // Configuration
-		"CWE-732",  // Incorrect Permission Assignment for Critical Resource
-		"CWE-400",  // Uncontrolled Resource Consumption
-		"CWE-119",  // Improper Restriction of Operations within Buffer
-		"CWE-125",  // Out-of-bounds Read
-		"CWE-787",  // Out-of-bounds Write
-		"CWE-416",  // Use After Free
-		"CWE-476",  // NULL Pointer Dereference
-		"CWE-Other", // Special case for uncategorized vulnerabilities
+		"CWE-79",     // Cross-site Scripting (XSS)
+		"CWE-89",     // SQL Injection
+		"CWE-22",     // Path Traversal
+		"CWE-352",    // Cross-Site Request Forgery (CSRF)
+		"CWE-434",    // Unrestricted Upload of File with Dangerous Type
+		"CWE-78",     // OS Command Injection
+		"CWE-601",    // URL Redirection to Untrusted Site ('Open Redirect')
+		"CWE-502",    // Deserialization of Untrusted Data
+		"CWE-287",    // Improper Authentication
+		"CWE-862",    // Missing Authorization
+		"CWE-798",    // Use of Hard-coded Credentials
+		"CWE-200",    // Information Exposure
+		"CWE-522",    // Insufficiently Protected Credentials
+		"CWE-319",    // Cleartext Transmission of Sensitive Information
+		"CWE-326",    // Inadequate Encryption Strength
+		"CWE-330",    // Use of Insufficiently Random Values
+		"CWE-16",     // Configuration
+		"CWE-732",    // Incorrect Permission Assignment for Critical Resource
+		"CWE-400",    // Uncontrolled Resource Consumption
+		"CWE-119",    // Improper Restriction of Operations within Buffer
+		"CWE-125",    // Out-of-bounds Read
+		"CWE-787",    // Out-of-bounds Write
+		"CWE-416",    // Use After Free
+		"CWE-476",    // NULL Pointer Dereference
+		"CWE-Other",  // Special case for uncategorized vulnerabilities
 		"CWE-noinfo", // Special case for no classification information
 	}
 }

--- a/pkg/samples/cwe.go
+++ b/pkg/samples/cwe.go
@@ -1,48 +1,42 @@
 package samples
 
-import (
-	"time"
-
-	"github.com/kptm-tools/common/common/pkg/results/tools"
-)
-
-func SampleCWEDetails() []tools.CWERemediation {
-	return []tools.CWERemediation{
-		{
-			ID:                 "CWE-79",
-			Title:              "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
-			Phase:              []string{"Implementation"},
-			Description:        "Ensure that all user-supplied input is properly sanitized, validated, or encoded before being rendered on a page.",
-			Effectiveness:      "Not effective",
-			EffectivenessNotes: "",
-			LastUpdated:        time.Now().UTC(),
-		},
-		{
-			ID:                 "CWE-89",
-			Title:              "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')",
-			Phase:              []string{"Implementation", "Phase 2"},
-			Description:        "Use parameterized queries or prepared statements instead of dynamic SQL string concatenation.",
-			Effectiveness:      "Slightly effective",
-			EffectivenessNotes: "Will only get rid of injection bug.",
-			LastUpdated:        time.Now().UTC(),
-		},
-		{
-			ID:                 "CWE-22",
-			Title:              "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
-			Phase:              []string{"Implementation"},
-			Description:        "Sanitize all user-controllable filenames and paths. Use an allow-list of paths and filenames.",
-			Effectiveness:      "Very effective",
-			EffectivenessNotes: "Must be thorough.",
-			LastUpdated:        time.Now().UTC(),
-		},
-		{
-			ID:                 "CWE-22",
-			Title:              "Copy of Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
-			Phase:              []string{"Implementation"},
-			Description:        "Copy of Sanitize all user-controllable filenames and paths. Use an allow-list of paths and filenames.",
-			Effectiveness:      "Very effective",
-			EffectivenessNotes: "Must be thorough.",
-			LastUpdated:        time.Now().UTC(),
-		},
+// RealisticCWEIDs returns a list of common CWE IDs that would be found by real vulnerability scanners.
+// These reference the pre-populated CWE knowledge base and represent what producers would actually send.
+func RealisticCWEIDs() []string {
+	return []string{
+		"CWE-79",   // Cross-site Scripting (XSS)
+		"CWE-89",   // SQL Injection
+		"CWE-22",   // Path Traversal
+		"CWE-352",  // Cross-Site Request Forgery (CSRF)
+		"CWE-434",  // Unrestricted Upload of File with Dangerous Type
+		"CWE-78",   // OS Command Injection
+		"CWE-601",  // URL Redirection to Untrusted Site ('Open Redirect')
+		"CWE-502",  // Deserialization of Untrusted Data
+		"CWE-287",  // Improper Authentication
+		"CWE-862",  // Missing Authorization
+		"CWE-798",  // Use of Hard-coded Credentials
+		"CWE-200",  // Information Exposure
+		"CWE-522",  // Insufficiently Protected Credentials
+		"CWE-319",  // Cleartext Transmission of Sensitive Information
+		"CWE-326",  // Inadequate Encryption Strength
+		"CWE-330",  // Use of Insufficiently Random Values
+		"CWE-16",   // Configuration
+		"CWE-732",  // Incorrect Permission Assignment for Critical Resource
+		"CWE-400",  // Uncontrolled Resource Consumption
+		"CWE-119",  // Improper Restriction of Operations within Buffer
+		"CWE-125",  // Out-of-bounds Read
+		"CWE-787",  // Out-of-bounds Write
+		"CWE-416",  // Use After Free
+		"CWE-476",  // NULL Pointer Dereference
+		"CWE-Other", // Special case for uncategorized vulnerabilities
+		"CWE-noinfo", // Special case for no classification information
 	}
+}
+
+// GetRandomCWEID returns a random CWE ID from the realistic list
+func GetRandomCWEID() string {
+	cweIDs := RealisticCWEIDs()
+	// Use a simple approach since we don't have gofakeit here yet
+	// In practice, the calling code will handle randomization
+	return cweIDs[0] // Return first one for now, calling code can randomize
 }

--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -39,7 +39,7 @@ var predefinedOSProfiles = []tools.OSData{
 	},
 }
 
-func generateOSData(cweDetails []tools.CWERemediation) tools.OSData {
+func generateOSData() tools.OSData {
 	gofakeit.ShuffleAnySlice(predefinedOSProfiles)
 	selectedOSProfile := predefinedOSProfiles[0]
 
@@ -50,6 +50,6 @@ func generateOSData(cweDetails []tools.CWERemediation) tools.OSData {
 		Type:            selectedOSProfile.Type,
 		FingerPrint:     selectedOSProfile.FingerPrint,
 		CPE:             selectedOSProfile.CPE,
-		Vulnerabilities: generateVuln(4, time.Now(), cweDetails),
+		Vulnerabilities: generateVuln(4, time.Now()), // Updated to use new signature
 	}
 }

--- a/pkg/samples/scan_results.go
+++ b/pkg/samples/scan_results.go
@@ -139,17 +139,20 @@ func generateVendorComments(size int, fromDate time.Time) []tools.VendorComment 
 	return vendorComments
 }
 
-func generateVuln(size int, fromDate time.Time, cweDetails []tools.CWERemediation) []tools.Vulnerability {
+func generateVuln(size int, fromDate time.Time) []tools.Vulnerability {
 	severityType, exploitableType, accessType, complexityType, privilegeRequiredType, likelihoodType, integrityImpact := generateDefaultEnumsVuln()
+	realisticCWEIDs := RealisticCWEIDs()
 
 	vulns := make([]tools.Vulnerability, size)
 	for i := range vulns {
-		randomCWE := cweDetails[gofakeit.IntRange(0, len(cweDetails)-1)]
+		// Use realistic CWE IDs that reference the pre-populated knowledge base
+		randomCWEID := realisticCWEIDs[gofakeit.IntRange(0, len(realisticCWEIDs)-1)]
 		vulns[i] = tools.Vulnerability{
 			ID:                 uuid.New(),
-			CveID:              "CVE-2020" + strconv.Itoa(gofakeit.Number(1, len(cweDetails))),
+			CveID:              "CVE-2024-" + fmt.Sprintf("%04d", gofakeit.Number(1, 9999)),
 			Type:               enums.AllOwaspCategories[gofakeit.IntRange(0, len(enums.AllOwaspCategories)-1)],
-			CWERemediation:     []tools.CWERemediation{randomCWE},
+			CweID:              randomCWEID, // Now using CweID field directly
+			CWERemediation:     []tools.CWERemediation{}, // Empty since we rely on pre-populated database
 			BaseCVSSScore:      math.Trunc(gofakeit.Float64Range(0, 10)*10) / 10,
 			BaseSeverity:       severityType[gofakeit.IntRange(0, 5)],
 			Access:             accessType[gofakeit.IntRange(0, 4)],
@@ -328,18 +331,17 @@ func generateDefaultEnumsVuln() ([]enums.SeverityType, []enums.ExploitabilityTyp
 	return severityType, exploitableType, accessType, complexityType, privilegeRequiredType, likelihoodType, integrityImpact
 }
 
-func generateNmapResult(scan domain.Scan, cweDetails []tools.CWERemediation) tools.NmapResult {
-
+func generateNmapResult(scan domain.Scan) tools.NmapResult {
 	return tools.NmapResult{
 		HostName:     gofakeit.DomainName(),
 		HostAddress:  gofakeit.IPv4Address(),
-		MostLikelyOS: generateOSData(cweDetails),
-		ScannedPorts: generatePortsData(gofakeit.Number(1, 10), *scan.EndedAt, cweDetails),
+		MostLikelyOS: generateOSData(), // Updated to new signature
+		ScannedPorts: generatePortsData(gofakeit.Number(1, 10), *scan.EndedAt), // Updated to new signature
 	}
 }
 
-func SampleNmapScanResults(scan domain.Scan, cweDetail []tools.CWERemediation) tools.NmapResult {
-	return generateNmapResult(scan, cweDetail)
+func SampleNmapScanResults(scan domain.Scan) tools.NmapResult {
+	return generateNmapResult(scan) // Updated to new signature
 }
 
 func SampleWebScanResults() tools.WebScanResult {
@@ -367,10 +369,13 @@ func generateWebVulnerabilities() []tools.WebVulnerability {
 		"Broken Authentication",
 	}
 
+	realisticCWEIDs := RealisticCWEIDs()
 	sizeWebVulns := gofakeit.Number(1, len(webVulnNames))
 	webVulns := make([]tools.WebVulnerability, 0, sizeWebVulns)
 	gofakeit.ShuffleAnySlice(webVulnNames)
 	for i := 0; i < sizeWebVulns; i++ {
+		// Use realistic CWE IDs that reference the pre-populated knowledge base
+		randomCWEID := realisticCWEIDs[gofakeit.IntRange(0, len(realisticCWEIDs)-1)]
 		webVuln := tools.WebVulnerability{
 			Name:       webVulnNames[i],
 			Risk:       enums.RiskCodeType(gofakeit.RandomString([]string{"Low", "Medium", "High", "Informational"})),
@@ -378,7 +383,7 @@ func generateWebVulnerabilities() []tools.WebVulnerability {
 			Confidence: enums.ConfidenceWebScanType(gofakeit.RandomString([]string{"Low", "Medium", "High", "FalsePositive"})),
 			Solution:   gofakeit.LoremIpsumWord(),
 			Reference:  gofakeit.URL(),
-			CweID:      "CWE-" + strconv.Itoa(gofakeit.Number(1, 1000)),
+			CweID:      randomCWEID, // Now using realistic CWE IDs from pre-populated database
 			WascID:     "WASC-" + strconv.Itoa(gofakeit.Number(1, 100)),
 		}
 		webVulns = append(webVulns, webVuln)

--- a/pkg/samples/scan_results.go
+++ b/pkg/samples/scan_results.go
@@ -151,7 +151,7 @@ func generateVuln(size int, fromDate time.Time) []tools.Vulnerability {
 			ID:                 uuid.New(),
 			CveID:              "CVE-2024-" + fmt.Sprintf("%04d", gofakeit.Number(1, 9999)),
 			Type:               enums.AllOwaspCategories[gofakeit.IntRange(0, len(enums.AllOwaspCategories)-1)],
-			CweID:              randomCWEID, // Now using CweID field directly
+			CweID:              randomCWEID,              // Now using CweID field directly
 			CWERemediation:     []tools.CWERemediation{}, // Empty since we rely on pre-populated database
 			BaseCVSSScore:      math.Trunc(gofakeit.Float64Range(0, 10)*10) / 10,
 			BaseSeverity:       severityType[gofakeit.IntRange(0, 5)],
@@ -335,7 +335,7 @@ func generateNmapResult(scan domain.Scan) tools.NmapResult {
 	return tools.NmapResult{
 		HostName:     gofakeit.DomainName(),
 		HostAddress:  gofakeit.IPv4Address(),
-		MostLikelyOS: generateOSData(), // Updated to new signature
+		MostLikelyOS: generateOSData(),                                         // Updated to new signature
 		ScannedPorts: generatePortsData(gofakeit.Number(1, 10), *scan.EndedAt), // Updated to new signature
 	}
 }

--- a/pkg/samples/service.go
+++ b/pkg/samples/service.go
@@ -30,7 +30,7 @@ var predefinedServiceProfiles = []serviceProfile{
 	{PortID: 8080, Protocol: "tcp", ServiceName: "http-proxy", Product: "Apache Tomcat", Version: "9.0.65", CPE: "cpe:/a:apache:tomcat:9.0.65"},
 }
 
-func generatePortsData(size int, fromDate time.Time, cweDetails []tools.CWERemediation) []tools.PortData {
+func generatePortsData(size int, fromDate time.Time) []tools.PortData {
 	ports := make([]tools.PortData, size)
 	half := size / 2
 	for i := 0; i < half; i++ {
@@ -47,7 +47,7 @@ func generatePortsData(size int, fromDate time.Time, cweDetails []tools.CWERemed
 				CPE:        selectedService.CPE,
 			},
 			Product:         selectedService.Product,
-			Vulnerabilities: generateVuln(gofakeit.IntRange(0, 10), fromDate, cweDetails),
+			Vulnerabilities: generateVuln(gofakeit.IntRange(0, 10), fromDate), // Updated signature
 		}
 	}
 	for i := half; i < size; i++ {
@@ -65,7 +65,7 @@ func generatePortsData(size int, fromDate time.Time, cweDetails []tools.CWERemed
 				CPE:        selectedService.CPE,
 			},
 			Product:         selectedService.Product,
-			Vulnerabilities: generateVuln(gofakeit.IntRange(0, 10), fromDate, cweDetails),
+			Vulnerabilities: generateVuln(gofakeit.IntRange(0, 10), fromDate), // Updated signature
 		}
 	}
 	return ports

--- a/pkg/services/scanschedule.go
+++ b/pkg/services/scanschedule.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/enums"
 
-	"github.com/kptm-tools/core-service/pkg/convert"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
+	"github.com/kptm-tools/core-service/pkg/utils"
 )
 
 type ScanScheduleService struct {
@@ -108,7 +108,7 @@ func (s *ScanScheduleService) PatchScanSchedule(
 	if frequency != nil {
 		isRepeated = true
 		periodName = string(frequency.UnitOfFrequency)
-		periodQuantity, err = convert.SafeIntToInt32(frequency.Quantity)
+		periodQuantity, err = utils.SafeIntToInt32(frequency.Quantity)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/utils.go
+++ b/pkg/services/utils.go
@@ -2,8 +2,6 @@ package services
 
 import (
 	"github.com/kptm-tools/common/common/pkg/results/tools"
-	"github.com/kptm-tools/core-service/pkg/domain"
-	"time"
 )
 
 // GeneratePortDataFromWebVuln creates PortData based on WebVulnerability information
@@ -25,42 +23,5 @@ func GeneratePortDataFromWebVuln(vuln tools.WebVulnerability) tools.PortData {
 	return portData
 }
 
-// GenerateCWEDetailFromVuln creates CWEDetail from tools.Vulnerability
-func GenerateCWEDetailFromVuln(vuln tools.Vulnerability) domain.CWEDetail {
-	// Extract title from first CWERemediation record
-	title := ExtractCWETitleFromRemediation(vuln.CWERemediation)
-	lastUpdate := ExtractCWELastUpdatedAtFromRemediation(vuln.CWERemediation)
-	now := time.Now()
-	return domain.CWEDetail{
-		ID:          vuln.CweID,
-		Title:       title,
-		CreatedAt:   &now,
-		LastUpdated: lastUpdate,
-	}
-}
-
-// GenerateCWEDetailFromWebVuln creates CWEDetail from tools.WebVulnerability
-func GenerateCWEDetailFromWebVuln(vuln tools.WebVulnerability) domain.CWEDetail {
-	now := time.Now()
-	return domain.CWEDetail{
-		ID:          vuln.CweID,
-		CreatedAt:   &now,
-		LastUpdated: &now,
-	}
-}
-
-// ExtractCWETitleFromRemediation extracts title from CWE remediation data
-func ExtractCWETitleFromRemediation(remediations []tools.CWERemediation) string {
-	if len(remediations) > 0 {
-		return remediations[0].Title
-	}
-	return ""
-}
-
-// ExtractCWELastUpdatedAtFromRemediation extracts title from CWE remediation data
-func ExtractCWELastUpdatedAtFromRemediation(remediations []tools.CWERemediation) *time.Time {
-	if len(remediations) > 0 {
-		return &remediations[0].LastUpdated
-	}
-	return nil
-}
+// Removed GenerateCWEDetailFromVuln and related functions as they are no longer needed.
+// CWE data is now pre-populated in the database and only stub records are created for unknown CWEs.

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -76,17 +76,10 @@ func (s *VulnerabilityService) CreateNetworkOSVulnerabilities(
 			if errCreateCVE != nil {
 				return fmt.Errorf("failed to insert os vulnerability CVE detail: %w", errCreateCVE)
 			}
-			// 2.1.2 Store CWE detail of the vuln
-			_, errCreateCWE := s.cweRepo.CreateOrUpdateCWE(ctx, GenerateCWEDetailFromVuln(vuln))
-			if errCreateCWE != nil {
-				return fmt.Errorf("failed to insert os vulnerability CWE detail: %w", errCreateCWE)
-			}
-			for _, remediation := range vuln.CWERemediation {
-				// 2.1.2.1. Store the CWE remediations and upsert if it exists
-				_, errCWERemediation := s.cweRepo.CreateCWERemediation(ctx, &remediation)
-				if errCWERemediation != nil {
-					return fmt.Errorf("failed to insert os vulnerability CWE remediation: %w", errCWERemediation)
-				}
+			// 2.1.2 Ensure CWE exists in database (create stub if unknown)
+			errEnsureCWE := s.ensureCWEExists(ctx, vuln.CweID)
+			if errEnsureCWE != nil {
+				return fmt.Errorf("failed to ensure CWE exists for %s: %w", vuln.CweID, errEnsureCWE)
 			}
 			// 2.1.3 Create a Vulnerability Record
 			dbVuln, errCreateVuln := s.vulnerRepo.CreateVulnerability(ctx, scan.HostID, scan.ID, vuln)
@@ -115,17 +108,10 @@ func (s *VulnerabilityService) CreateNetworkOSVulnerabilities(
 				if errCreateCVE != nil {
 					return fmt.Errorf("failed to insert port vulnerability CVE detail: %w", errCreateCVE)
 				}
-				_, errCreateCWE := s.cweRepo.CreateOrUpdateCWE(ctx, GenerateCWEDetailFromVuln(vuln))
-				if errCreateCWE != nil {
-					return fmt.Errorf("failed to insert os vulnerability CWE detail: %w", errCreateCWE)
-				}
-				// 3.2.2 Store CWE remediations for the vuln
-				for _, remediation := range vuln.CWERemediation {
-					_, errCWERemediation := s.cweRepo.CreateCWERemediation(ctx, &remediation)
-					if errCWERemediation != nil {
-						slog.Debug("failed to insert os vulnerability CWE remediation", slog.Any("error", errCWERemediation))
-						return fmt.Errorf("failed to insert os vulnerability CWE remediation: %w", errCWERemediation)
-					}
+				// 3.2.2 Ensure CWE exists in database (create stub if unknown)
+				errEnsureCWE := s.ensureCWEExists(ctx, vuln.CweID)
+				if errEnsureCWE != nil {
+					return fmt.Errorf("failed to ensure CWE exists for %s: %w", vuln.CweID, errEnsureCWE)
 				}
 
 				// 3.2.3 Create a Vulnerability record
@@ -367,6 +353,28 @@ func calculateVulnerabiltyAgeDays(timePublished time.Time) int {
 	return int(durationInDaysFloat)
 }
 
+// ensureCWEExists checks if a CWE exists in the database and creates a stub record if it doesn't (Option A)
+func (s *VulnerabilityService) ensureCWEExists(ctx context.Context, cweID string) error {
+	if cweID == "" {
+		return nil // Skip empty CWE IDs
+	}
+	
+	exists, err := s.cweRepo.CWEExists(ctx, cweID)
+	if err != nil {
+		return fmt.Errorf("failed to check if CWE exists: %w", err)
+	}
+	
+	if !exists {
+		// Create stub record for unknown CWE (Option A)
+		_, err := s.cweRepo.CreateCWEStub(ctx, cweID)
+		if err != nil {
+			return fmt.Errorf("failed to create CWE stub for %s: %w", cweID, err)
+		}
+	}
+	
+	return nil
+}
+
 func (s *VulnerabilityService) CreateVulnerabilityComment(
 	ctx context.Context,
 	vulnID uuid.UUID,
@@ -429,11 +437,10 @@ func (s *VulnerabilityService) InsertWebScanVulnerabilities(ctx context.Context,
 					return fmt.Errorf("failed to create or update service: %w", err)
 				}
 			}
-			// 2.1.1 Store CWE detail of the vuln
-			_, err = s.cweRepo.CreateOrUpdateCWE(ctx, GenerateCWEDetailFromWebVuln(vuln))
-
-			if err != nil {
-				return fmt.Errorf("failed to insert web scan vulnerability CWE detail: %w", err)
+			// 2.1.1 Ensure CWE exists in database (create stub if unknown)
+			errEnsureCWE := s.ensureCWEExists(ctx, vuln.CweID)
+			if errEnsureCWE != nil {
+				return fmt.Errorf("failed to ensure CWE exists for %s: %w", vuln.CweID, errEnsureCWE)
 			}
 
 			// 2.1.3 Create a Vulnerability Record

--- a/pkg/services/vulnerability.go
+++ b/pkg/services/vulnerability.go
@@ -358,12 +358,12 @@ func (s *VulnerabilityService) ensureCWEExists(ctx context.Context, cweID string
 	if cweID == "" {
 		return nil // Skip empty CWE IDs
 	}
-	
+
 	exists, err := s.cweRepo.CWEExists(ctx, cweID)
 	if err != nil {
 		return fmt.Errorf("failed to check if CWE exists: %w", err)
 	}
-	
+
 	if !exists {
 		// Create stub record for unknown CWE (Option A)
 		_, err := s.cweRepo.CreateCWEStub(ctx, cweID)
@@ -371,7 +371,7 @@ func (s *VulnerabilityService) ensureCWEExists(ctx context.Context, cweID string
 			return fmt.Errorf("failed to create CWE stub for %s: %w", cweID, err)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/pkg/services/vulnerability_test.go
+++ b/pkg/services/vulnerability_test.go
@@ -117,8 +117,9 @@ func TestVulnerabilityService_CreateNetworkOSVulnerabilities_Success_Remediation
 	mockCVERepo.MockCreateOrUpdateCVE = func(ctx context.Context, vuln tools.Vulnerability) (*repository.CveDetail, error) {
 		return &repository.CveDetail{CveID: vuln.CveID}, nil
 	}
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerability = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.Vulnerability) (*domain.Vulnerability, error) {
 		if vuln.CveID == "CVE-2024-0001" { // OS vuln
@@ -134,9 +135,7 @@ func TestVulnerabilityService_CreateNetworkOSVulnerabilities_Success_Remediation
 		assert.Equal(t, int32(101), osID)
 		return nil
 	}
-	mockCWERepo.MockCreateCWERemediation = func(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error) {
-		return &tools.CWERemediation{ID: remediation.ID}, nil
-	}
+	// CWE remediation creation removed - no longer needed with refactored approach
 	// 3. Service Vulnerability processing
 	mockServiceRepo.MockCreateOrUpdateService = func(ctx context.Context, hID, sID uuid.UUID, portData tools.PortData) (*domain.Service, error) {
 		return &domain.Service{ID: 202}, nil
@@ -198,8 +197,9 @@ func TestVulnerabilityService_CreateNetworkOSVulnerabilities_Success_NoRemediati
 	mockCVERepo.MockCreateOrUpdateCVE = func(ctx context.Context, vuln tools.Vulnerability) (*repository.CveDetail, error) {
 		return &repository.CveDetail{CveID: vuln.CveID}, nil
 	}
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerability = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.Vulnerability) (*domain.Vulnerability, error) {
 		if vuln.CveID == "CVE-2024-0001" { // OS vuln
@@ -589,8 +589,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Success(t *testing.T)
 		return &repository.CveDetail{CveID: vuln.CveID}, nil
 	}
 
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil
@@ -679,8 +680,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilitiesWhenServiceNOTExists_S
 		assert.Equal(t, scanID, id)
 		return &domain.Scan{ID: scanID, HostID: hostID}, nil
 	}
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil
@@ -769,8 +771,12 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_SuccessEvenIfCWEEmpty
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil
 	}
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return nil, nil
+	// New refactored approach: Mock CWE existence check for empty CWE case
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return false, nil // For empty CWE test cases
+	}
+	mockCWERepo.MockCreateCWEStub = func(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
+		return &domain.CWEDetail{ID: cweID, Title: "Unknown Weakness"}, nil
 	}
 
 	// 3. Service Vulnerability processing
@@ -862,8 +868,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_SuccessEvenIfWASCEmpt
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil
 	}
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 
 	// 3. Service Vulnerability processing
@@ -974,8 +981,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Fail_WhenErrorVulnera
 		return &repository.CveDetail{CveID: vuln.CveID}, nil
 	}
 
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return nil, errors.New("vulnerability exists")
@@ -1050,8 +1058,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Fail_WhenErrorWebVuln
 		return &domain.Scan{ID: scanID, HostID: hostID}, nil
 	}
 
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil
@@ -1138,8 +1147,9 @@ func TestVulnerabilityService_CreateWebScanVulnerabilities_Fail_WhenErrorWebVuln
 		return &repository.CveDetail{CveID: vuln.CveID}, nil
 	}
 
-	mockCWERepo.MockCreateOrUpdateCWE = func(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-		return &domain.CWEDetail{ID: "CWE-" + cwe.ID}, nil
+	// New refactored approach: Mock CWE existence check (assumes CWE exists in pre-populated DB)
+	mockCWERepo.MockCWEExists = func(ctx context.Context, cweID string) (bool, error) {
+		return true, nil // Assume CWE exists in pre-populated database
 	}
 	mockVulnRepo.MockCreateVulnerabilityFromWebVuln = func(ctx context.Context, hID, sID uuid.UUID, vuln tools.WebVulnerability) (*domain.Vulnerability, error) {
 		return &domain.Vulnerability{ID: uuid.New()}, nil

--- a/pkg/storage/cwe.go
+++ b/pkg/storage/cwe.go
@@ -175,7 +175,7 @@ func (r *CWERepo) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID str
 			MitigationDescription: dbCWE.MitigationDescription.String,
 			Effectiveness:         dbCWE.Effectiveness.String,
 			EffectivenessNotes:    dbCWE.EffectivenessNotes.String,
-			MigrationCreatedAt:    dbCWE.MitigationCreatedAt.Time,
+			MitigationCreatedAt:   dbCWE.MitigationCreatedAt.Time,
 		}
 	}
 	return remediationDetails, nil
@@ -204,5 +204,61 @@ func (r *CWERepo) CreateOrUpdateCWEFromWebVulnerability(ctx context.Context, vul
 		Title:       dbCWE.Title,
 		Description: dbCWE.Description,
 		LastUpdated: dbCWE.LastUpdated,
+	}, nil
+}
+
+// New methods for refactored approach
+
+// GetCWEByID retrieves a CWE detail by its ID from the pre-populated database
+func (r *CWERepo) GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
+	queries := r.getQueries(ctx)
+	
+	dbCWE, err := queries.GetCWEDetailByCWEID(ctx, cweID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // CWE not found
+		}
+		return nil, err
+	}
+	
+	return &domain.CWEDetail{
+		ID:          dbCWE.CweID,
+		Title:       dbCWE.Title,
+		Description: dbCWE.Description,
+		LastUpdated: &dbCWE.LastUpdated,
+	}, nil
+}
+
+// CWEExists checks if a CWE exists in the pre-populated database
+func (r *CWERepo) CWEExists(ctx context.Context, cweID string) (bool, error) {
+	cwe, err := r.GetCWEByID(ctx, cweID)
+	if err != nil {
+		return false, err
+	}
+	return cwe != nil, nil
+}
+
+// CreateCWEStub creates a minimal CWE record for unknown CWE IDs (Option A)
+func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
+	queries := r.getQueries(ctx)
+	
+	// Create a stub record with minimal information
+	params := repository.CreateOrUpdateCWEDetailParams{
+		CweID:       cweID,
+		Title:       "Unknown Weakness",
+		Description: "This CWE ID was not found in the pre-populated knowledge base. Manual review recommended.",
+		LastUpdated: time.Now().UTC(),
+	}
+	
+	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &domain.CWEDetail{
+		ID:          dbCWE.CweID,
+		Title:       dbCWE.Title,
+		Description: dbCWE.Description,
+		LastUpdated: &dbCWE.LastUpdated,
 	}, nil
 }

--- a/pkg/storage/cwe.go
+++ b/pkg/storage/cwe.go
@@ -31,32 +31,7 @@ func (r *CWERepo) getQueries(ctx context.Context) *repository.Queries {
 	return GetQueriesFromContext(ctx, r.defaultQueries)
 }
 
-func (r *CWERepo) CreateOrUpdateCWE(ctx context.Context, cwe domain.CWEDetail) (*domain.CWEDetail, error) {
-	if cwe.ID == "" {
-		return nil, nil
-	}
-
-	queries := r.getQueries(ctx)
-
-	params := repository.CreateOrUpdateCWEDetailParams{
-		CweID:       cwe.ID,
-		Title:       cwe.Title,
-		Description: cwe.Description,
-		LastUpdated: time.Now(),
-	}
-
-	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	return &domain.CWEDetail{
-		ID:          dbCWE.CweID,
-		Title:       dbCWE.Title,
-		Description: dbCWE.Description,
-		LastUpdated: &dbCWE.LastUpdated,
-	}, nil
-}
+// CreateOrUpdateCWE method removed - no longer needed with pre-populated CWE approach
 
 func (r *CWERepo) CreateCWERemediation(ctx context.Context, remediation *tools.CWERemediation) (*tools.CWERemediation, error) {
 	queries := r.getQueries(ctx)
@@ -181,38 +156,14 @@ func (r *CWERepo) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID str
 	return remediationDetails, nil
 }
 
-func (r *CWERepo) CreateOrUpdateCWEFromWebVulnerability(ctx context.Context, vuln tools.WebVulnerability) (*tools.CWERemediation, error) {
-	if vuln.CweID == "" {
-		return nil, nil
-	}
-
-	queries := r.getQueries(ctx)
-
-	params := repository.CreateOrUpdateCWEDetailParams{
-		CweID:       vuln.CweID,
-		Title:       "",
-		Description: "",
-		LastUpdated: time.Now(),
-	}
-	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tools.CWERemediation{
-		ID:          dbCWE.CweID,
-		Title:       dbCWE.Title,
-		Description: dbCWE.Description,
-		LastUpdated: dbCWE.LastUpdated,
-	}, nil
-}
+// CreateOrUpdateCWEFromWebVulnerability method removed - no longer needed with pre-populated CWE approach
 
 // New methods for refactored approach
 
 // GetCWEByID retrieves a CWE detail by its ID from the pre-populated database
 func (r *CWERepo) GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
 	queries := r.getQueries(ctx)
-	
+
 	dbCWE, err := queries.GetCWEDetailByCWEID(ctx, cweID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -220,7 +171,7 @@ func (r *CWERepo) GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDeta
 		}
 		return nil, err
 	}
-	
+
 	return &domain.CWEDetail{
 		ID:          dbCWE.CweID,
 		Title:       dbCWE.Title,
@@ -241,7 +192,7 @@ func (r *CWERepo) CWEExists(ctx context.Context, cweID string) (bool, error) {
 // CreateCWEStub creates a minimal CWE record for unknown CWE IDs (Option A)
 func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWEDetail, error) {
 	queries := r.getQueries(ctx)
-	
+
 	// Create a stub record with minimal information
 	params := repository.CreateOrUpdateCWEDetailParams{
 		CweID:       cweID,
@@ -249,12 +200,12 @@ func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWED
 		Description: "This CWE ID was not found in the pre-populated knowledge base. Manual review recommended.",
 		LastUpdated: time.Now().UTC(),
 	}
-	
+
 	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &domain.CWEDetail{
 		ID:          dbCWE.CweID,
 		Title:       dbCWE.Title,

--- a/pkg/storage/listener.go
+++ b/pkg/storage/listener.go
@@ -12,8 +12,8 @@ import (
 
 	cmmn "github.com/kptm-tools/common/common/pkg/events"
 	"github.com/kptm-tools/core-service/pkg/config"
-	"github.com/kptm-tools/core-service/pkg/convert"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
+	"github.com/kptm-tools/core-service/pkg/utils"
 	"github.com/lib/pq"
 )
 
@@ -176,7 +176,7 @@ func (pl *PostgresListener) handleScanCronNotification(ctx context.Context, payl
 	}
 	pl.eventBus.Publish(string(enums.ScanStartedEventSubject), scanStartedBytes)
 
-	scheduleID, err := convert.SafeIntToInt32(scanCron.ScanScheduleID)
+	scheduleID, err := utils.SafeIntToInt32(scanCron.ScanScheduleID)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/os.go
+++ b/pkg/storage/os.go
@@ -9,10 +9,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	repository "github.com/kptm-tools/core-service/db"
-	"github.com/kptm-tools/core-service/pkg/convert"
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 	"github.com/kptm-tools/core-service/pkg/domain"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
+	"github.com/kptm-tools/core-service/pkg/utils"
 )
 
 type OSRepo struct {
@@ -40,7 +40,7 @@ func (r *OSRepo) CreateOS(
 	scanID uuid.UUID,
 	osData tools.OSData,
 ) (*domain.OperatingSystem, error) {
-	acc, err := convert.SafeIntToInt32(osData.Accuracy)
+	acc, err := utils.SafeIntToInt32(osData.Accuracy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert osData Accuracy field to Int32: %w", err)
 	}

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// FindProjectRoot attempts to find the project root directory by looking for go.mod
+// It first tries to find it relative to the calling source file, then falls back
+// to the current working directory.
+func FindProjectRoot() (string, error) {
+	// Get the path of the calling source file (skip 1 frame to get caller)
+	_, filename, _, ok := runtime.Caller(1)
+	if !ok {
+		return "", fmt.Errorf("failed to get caller file path")
+	}
+
+	// Navigate up from the source file to find project root
+	dir := filepath.Dir(filename)
+
+	// Try different levels to find go.mod (indicator of project root)
+	for i := 0; i < 10; i++ {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root
+			break
+		}
+		dir = parent
+	}
+
+	// If go.mod not found via source file, fall back to current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Check if we're already in the project root
+	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
+		return cwd, nil
+	}
+
+	// Try going up from current directory
+	dir = cwd
+	for i := 0; i < 5; i++ {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("could not find project root (no go.mod found)")
+}

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -1,4 +1,4 @@
-package convert
+package utils
 
 import (
 	"fmt"


### PR DESCRIPTION
This pull request introduces significant changes to decouple the CWE knowledge base from the event stream, improve database population processes, and refactor related code to align with the new architecture. The changes include introducing a pre-population script for CWE data, simplifying event payloads, and refactoring the codebase to support the new approach. Below is a summary of the most important changes grouped by theme:

### CWE Knowledge Base Decoupling and Refactoring
* Added a new SQL query and function `GetCWEDetailByCWEID` to retrieve CWE details by ID in `db/cwe_detail.sql.go` and `db/sql/queries/cwe_detail.sql`. This supports the decoupled architecture by enabling read-time data access. [[1]](diffhunk://#diff-4bc5e976a1daee8dfc8637ef49c024227e8afda0e4cb0bad4d2cf259c23a5495R54-R72) [[2]](diffhunk://#diff-b4540390109b77a15f9ad020b1bbb18cfa2e5a1ddd17620e721f9da60f221cecR15-R19)
* Refactored `pkg/domain/cwe.go` to define new structs (`CWEDetail`, `CWEDetailWithMitigations`, and `CWEMitigation`) for handling CWE data, ensuring compatibility with the pre-populated knowledge base approach.
* Updated `pkg/interfaces/vulnerability.go` to include new methods (`GetCWEByID`, `CWEExists`, `CreateCWEStub`, etc.) in the `CWERepository` interface, aligning with the refactored approach. Legacy methods are retained for the pre-population script.
* Modified `pkg/mocks/storage/cwe.go` to implement the new `CWERepository` methods for testing purposes and removed the deprecated `CreateOrUpdateCWE` method. [[1]](diffhunk://#diff-07cbf2540672be6a2f73e2e05bbfa4fba31b24d2b3eb85bb4d5a5047b909508aL14-R28) [[2]](diffhunk://#diff-07cbf2540672be6a2f73e2e05bbfa4fba31b24d2b3eb85bb4d5a5047b909508aR50-R79)

### Database Population Enhancements
* Enhanced `db/sampledata/main.go` to include a comprehensive database population process with a new `populateCWEKnowledgeBase` function for pre-populating CWE data using a `cwe.json` file. This ensures the database is seeded with static CWE data before runtime.
* Simplified `populateScans` and `populateNetworkOSVulnerabilities` functions by removing redundant CWE details as input, leveraging the pre-populated database instead. [[1]](diffhunk://#diff-3109f03a5757dca7cf33cfc9312b6d05efa3ba06845ad3d2344d8c2e870ae59bL131-R168) [[2]](diffhunk://#diff-3109f03a5757dca7cf33cfc9312b6d05efa3ba06845ad3d2344d8c2e870ae59bL166-R204)

### Architectural Documentation
* Added `docs/adr/ADR-004.md` to document the decision to decouple the CWE knowledge base from the event stream. This includes the rationale, implementation details, and consequences of the new architecture.

### Configuration and Environment Updates
* Updated `bruno/core-service/environments/kptm-tools.bru` to define `hostID`, `scanID`, and other variables as static values and moved sensitive variables (`auth_token`, `OTP`) to a `vars:secret` block for better security.

### Miscellaneous Changes
* Updated `bruno/core-service/Login with Core-Service.bru` and `Register Host.bru` to include post-response scripts for extracting and storing tokens and host IDs in environment variables. These changes improve automation in API testing. [[1]](diffhunk://#diff-ed33af3e72c8151e943b66ec0c9d5cbb87f863af746bdc300451f87a1bbc69a4L19-R31) [[2]](diffhunk://#diff-b7e70b292c55bc3e88ecf4c95fc77e09d9ea791c6e6abbe8b816b34e587edee7R37-R44)

These changes collectively improve system performance, reduce payload sizes, and decouple the architecture, while introducing a more efficient approach to managing CWE data.