### PR TITLE
Bug/kt 539 scan assets view shows incorrect and incomplete vulnerability counts

### DIFF
--- a/db/scan.sql.go
+++ b/db/scan.sql.go
@@ -57,7 +57,67 @@ func (q *Queries) CreateScan(ctx context.Context, arg CreateScanParams) (Scan, e
 }
 
 const getAssetsByScanID = `-- name: GetAssetsByScanID :many
-WITH os_assets AS (
+WITH network_vuln_counts AS (
+    -- Step 1: Count vulnerabilities linked via the network_os_vulnerabilities table (for OS and Services)
+    SELECT
+        nov.operating_system_id,
+        nov.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+    FROM
+        vulnerabilities v
+    JOIN
+        network_os_vulnerabilities nov ON v.id = nov.vulnerability_id
+    WHERE
+        v.scan_id = $1
+    GROUP BY
+        nov.operating_system_id, nov.service_id
+),
+web_vuln_counts AS (
+    -- Step 2: Count vulnerabilities linked via the web_vulnerabilities table (for Services only)
+    SELECT
+        wv.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+    FROM
+        vulnerabilities v
+    JOIN
+        web_vulnerabilities wv ON v.id = wv.vulnerability_id
+    WHERE
+        v.scan_id = $1
+    GROUP BY
+        wv.service_id
+),
+combined_service_counts AS (
+    -- Step 3: Combine the counts for services, as they can have both network and web vulns.
+    SELECT
+        COALESCE(nvc.service_id, wvc.service_id) AS service_id,
+        COALESCE(nvc.total_vulnerabilities, 0) + COALESCE(wvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+        COALESCE(nvc.critical, 0) + COALESCE(wvc.critical, 0) AS critical_count,
+        COALESCE(nvc.high, 0) + COALESCE(wvc.high, 0) AS high_count,
+        COALESCE(nvc.medium, 0) + COALESCE(wvc.medium, 0) AS medium_count,
+        COALESCE(nvc.low, 0) + COALESCE(wvc.low, 0) AS low_count,
+        COALESCE(nvc.none, 0) + COALESCE(wvc.none, 0) AS none_count,
+        COALESCE(nvc.unknown, 0) + COALESCE(wvc.unknown, 0) AS unknown_count
+    FROM
+        network_vuln_counts nvc
+    FULL OUTER JOIN
+        web_vuln_counts wvc ON nvc.service_id = wvc.service_id
+    WHERE
+        nvc.service_id IS NOT NULL OR wvc.service_id IS NOT NULL
+),
+os_assets AS (
+    -- Step 4: Get the OS asset and join ONLY with network vulnerability counts.
     SELECT
         'os' AS asset_type,
         os.id,
@@ -74,36 +134,24 @@ WITH os_assets AS (
         NULL::VARCHAR AS product,
         os.accuracy,
         NULL::port_state_enum AS port_state,
-
-        COUNT(v.id) AS total_vulnerabilities_count,
-        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical_count,
-        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high_count,
-        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium_count,
-        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low_count,
-        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none_count,
-        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown_count,
-
+        COALESCE(nvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+        COALESCE(nvc.critical, 0) AS critical_count,
+        COALESCE(nvc.high, 0) AS high_count,
+        COALESCE(nvc.medium, 0) AS medium_count,
+        COALESCE(nvc.low, 0) AS low_count,
+        COALESCE(nvc.none, 0) AS none_count,
+        COALESCE(nvc.unknown, 0) AS unknown_count,
         os.created_at,
         os.updated_at
-    FROM operating_systems os
-    LEFT JOIN vulnerabilities v ON os.host_id = v.host_id
-                             AND os.scan_id = v.scan_id
-                             AND v.vuln_type = 'NETWORK_OS'
-    WHERE os.scan_id = $1
-    GROUP BY
-        os.id,
-        os.host_id,
-        os.scan_id,
-        os.os_name,
-        os.family,
-        os.os_type,
-        os.fingerprint,
-        os.cpe,
-        os.accuracy,
-        os.created_at,
-        os.updated_at
+    FROM
+        operating_systems os
+    LEFT JOIN
+        network_vuln_counts nvc ON os.id = nvc.operating_system_id
+    WHERE
+        os.scan_id = $1
 ),
 service_assets AS (
+    -- Step 5: Get Service assets and join with the COMBINED vulnerability counts.
     SELECT
         'service' AS asset_type,
         s.id,
@@ -120,36 +168,21 @@ service_assets AS (
         s.product,
         s.confidence AS accuracy,
         s.port_state,
-
-        COUNT(v.id) AS total_vulnerabilities_count,
-        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical_count,
-        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high_count,
-        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium_count,
-        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low_count,
-        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none_count,
-        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown_count,
-
+        COALESCE(csc.total_vulnerabilities_count, 0) AS total_vulnerabilities_count,
+        COALESCE(csc.critical_count, 0) AS critical_count,
+        COALESCE(csc.high_count, 0) AS high_count,
+        COALESCE(csc.medium_count, 0) AS medium_count,
+        COALESCE(csc.low_count, 0) AS low_count,
+        COALESCE(csc.none_count, 0) AS none_count,
+        COALESCE(csc.unknown_count, 0) AS unknown_count,
         s.created_at,
         s.updated_at
-    FROM services s
-    LEFT JOIN vulnerabilities v ON s.host_id = v.host_id
-                             AND s.scan_id = v.scan_id
-                             AND v.vuln_type = 'WEB_APPLICATION'
-    WHERE s.scan_id = $1
-    GROUP BY
-        s.id,
-        s.host_id,
-        s.scan_id,
-        s.sv_name,
-        s.sv_version,
-        s.port,
-        s.protocol,
-        s.cpe,
-        s.product,
-        s.confidence,
-        s.port_state,
-        s.created_at,
-        s.updated_at
+    FROM
+        services s
+    LEFT JOIN
+        combined_service_counts csc ON s.id = csc.service_id
+    WHERE
+        s.scan_id = $1
 )
 SELECT asset_type, id, host_id, scan_id, name, version, family, os_type, port, protocol, fingerprint, cpe, product, accuracy, port_state, total_vulnerabilities_count, critical_count, high_count, medium_count, low_count, none_count, unknown_count, created_at, updated_at FROM os_assets
 UNION ALL
@@ -184,6 +217,7 @@ type GetAssetsByScanIDRow struct {
 	UpdatedAt                 sql.NullTime      `json:"updated_at"`
 }
 
+// Step 6: Combine results.
 func (q *Queries) GetAssetsByScanID(ctx context.Context, scanID uuid.UUID) ([]GetAssetsByScanIDRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAssetsByScanID, scanID)
 	if err != nil {

--- a/db/sql/queries/scan.sql
+++ b/db/sql/queries/scan.sql
@@ -251,7 +251,67 @@ ORDER BY
 LIMIT 1;
 
 -- name: GetAssetsByScanID :many
-WITH os_assets AS (
+WITH network_vuln_counts AS (
+    -- Step 1: Count vulnerabilities linked via the network_os_vulnerabilities table (for OS and Services)
+    SELECT
+        nov.operating_system_id,
+        nov.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+    FROM
+        vulnerabilities v
+    JOIN
+        network_os_vulnerabilities nov ON v.id = nov.vulnerability_id
+    WHERE
+        v.scan_id = $1
+    GROUP BY
+        nov.operating_system_id, nov.service_id
+),
+web_vuln_counts AS (
+    -- Step 2: Count vulnerabilities linked via the web_vulnerabilities table (for Services only)
+    SELECT
+        wv.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+    FROM
+        vulnerabilities v
+    JOIN
+        web_vulnerabilities wv ON v.id = wv.vulnerability_id
+    WHERE
+        v.scan_id = $1
+    GROUP BY
+        wv.service_id
+),
+combined_service_counts AS (
+    -- Step 3: Combine the counts for services, as they can have both network and web vulns.
+    SELECT
+        COALESCE(nvc.service_id, wvc.service_id) AS service_id,
+        COALESCE(nvc.total_vulnerabilities, 0) + COALESCE(wvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+        COALESCE(nvc.critical, 0) + COALESCE(wvc.critical, 0) AS critical_count,
+        COALESCE(nvc.high, 0) + COALESCE(wvc.high, 0) AS high_count,
+        COALESCE(nvc.medium, 0) + COALESCE(wvc.medium, 0) AS medium_count,
+        COALESCE(nvc.low, 0) + COALESCE(wvc.low, 0) AS low_count,
+        COALESCE(nvc.none, 0) + COALESCE(wvc.none, 0) AS none_count,
+        COALESCE(nvc.unknown, 0) + COALESCE(wvc.unknown, 0) AS unknown_count
+    FROM
+        network_vuln_counts nvc
+    FULL OUTER JOIN
+        web_vuln_counts wvc ON nvc.service_id = wvc.service_id
+    WHERE
+        nvc.service_id IS NOT NULL OR wvc.service_id IS NOT NULL
+),
+os_assets AS (
+    -- Step 4: Get the OS asset and join ONLY with network vulnerability counts.
     SELECT
         'os' AS asset_type,
         os.id,
@@ -268,36 +328,24 @@ WITH os_assets AS (
         NULL::VARCHAR AS product,
         os.accuracy,
         NULL::port_state_enum AS port_state,
-
-        COUNT(v.id) AS total_vulnerabilities_count,
-        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical_count,
-        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high_count,
-        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium_count,
-        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low_count,
-        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none_count,
-        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown_count,
-
+        COALESCE(nvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+        COALESCE(nvc.critical, 0) AS critical_count,
+        COALESCE(nvc.high, 0) AS high_count,
+        COALESCE(nvc.medium, 0) AS medium_count,
+        COALESCE(nvc.low, 0) AS low_count,
+        COALESCE(nvc.none, 0) AS none_count,
+        COALESCE(nvc.unknown, 0) AS unknown_count,
         os.created_at,
         os.updated_at
-    FROM operating_systems os
-    LEFT JOIN vulnerabilities v ON os.host_id = v.host_id
-                             AND os.scan_id = v.scan_id
-                             AND v.vuln_type = 'NETWORK_OS'
-    WHERE os.scan_id = $1
-    GROUP BY
-        os.id,
-        os.host_id,
-        os.scan_id,
-        os.os_name,
-        os.family,
-        os.os_type,
-        os.fingerprint,
-        os.cpe,
-        os.accuracy,
-        os.created_at,
-        os.updated_at
+    FROM
+        operating_systems os
+    LEFT JOIN
+        network_vuln_counts nvc ON os.id = nvc.operating_system_id
+    WHERE
+        os.scan_id = $1
 ),
 service_assets AS (
+    -- Step 5: Get Service assets and join with the COMBINED vulnerability counts.
     SELECT
         'service' AS asset_type,
         s.id,
@@ -314,37 +362,23 @@ service_assets AS (
         s.product,
         s.confidence AS accuracy,
         s.port_state,
-
-        COUNT(v.id) AS total_vulnerabilities_count,
-        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical_count,
-        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high_count,
-        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium_count,
-        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low_count,
-        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none_count,
-        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown_count,
-
+        COALESCE(csc.total_vulnerabilities_count, 0) AS total_vulnerabilities_count,
+        COALESCE(csc.critical_count, 0) AS critical_count,
+        COALESCE(csc.high_count, 0) AS high_count,
+        COALESCE(csc.medium_count, 0) AS medium_count,
+        COALESCE(csc.low_count, 0) AS low_count,
+        COALESCE(csc.none_count, 0) AS none_count,
+        COALESCE(csc.unknown_count, 0) AS unknown_count,
         s.created_at,
         s.updated_at
-    FROM services s
-    LEFT JOIN vulnerabilities v ON s.host_id = v.host_id
-                             AND s.scan_id = v.scan_id
-                             AND v.vuln_type = 'WEB_APPLICATION'
-    WHERE s.scan_id = $1
-    GROUP BY
-        s.id,
-        s.host_id,
-        s.scan_id,
-        s.sv_name,
-        s.sv_version,
-        s.port,
-        s.protocol,
-        s.cpe,
-        s.product,
-        s.confidence,
-        s.port_state,
-        s.created_at,
-        s.updated_at
+    FROM
+        services s
+    LEFT JOIN
+        combined_service_counts csc ON s.id = csc.service_id
+    WHERE
+        s.scan_id = $1
 )
+-- Step 6: Combine results.
 SELECT * FROM os_assets
 UNION ALL
 SELECT * FROM service_assets

--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -265,7 +265,7 @@ type ScanVulnerabilityDetectedOSResponse struct {
 	TotalVulnerabilities int                     `json:"total_vulnerabilities"`
 	SeverityCounts       tools.SeverityCounts    `json:"severity_counts"`
 	Vulnerabilities      []ScanVulnerabilityItem `json:"vulnerabilities"`
-	CWERemediations      []CWERemediation        `json:"remediation"`
+	CWERemediations      []CWERemediation        `json:"remediations"`
 	References           []string                `json:"references"`
 }
 
@@ -283,7 +283,7 @@ type ScanVulnerabilityDetectedServiceResponse struct {
 	TotalVulnerabilities int                     `json:"total_vulnerabilities"`
 	SeverityCounts       tools.SeverityCounts    `json:"severity_counts"`
 	Vulnerabilities      []ScanVulnerabilityItem `json:"vulnerabilities"`
-	CWERemediations      []CWERemediation        `json:"remediation"`
+	CWERemediations      []CWERemediation        `json:"remediations"`
 	References           []string                `json:"references"`
 }
 

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -229,8 +229,8 @@ func TestScanHandlers_GetScanAssetsByID(t *testing.T) {
 				// Service: 3 total (0 critical, 1 high, 1 medium, 1 low)
 				// Total: 8 vulnerabilities
 				assert.Equal(t, 8, totalOverall, "Total vulnerabilities across all assets should match expected sum")
-				assert.Equal(t, 1, totalCritical, "Total critical vulnerabilities should match expected sum")   // 1 from OS + 0 from Service
-				assert.Equal(t, 3, totalHigh, "Total high vulnerabilities should match expected sum")         // 2 from OS + 1 from Service  
+				assert.Equal(t, 1, totalCritical, "Total critical vulnerabilities should match expected sum") // 1 from OS + 0 from Service
+				assert.Equal(t, 3, totalHigh, "Total high vulnerabilities should match expected sum")         // 2 from OS + 1 from Service
 				assert.Equal(t, 2, totalMedium, "Total medium vulnerabilities should match expected sum")     // 1 from OS + 1 from Service
 				assert.Equal(t, 2, totalLow, "Total low vulnerabilities should match expected sum")           // 1 from OS + 1 from Service
 			}

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/kptm-tools/common/common/pkg/events"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	"github.com/kptm-tools/core-service/pkg/domain"
+	"github.com/kptm-tools/core-service/pkg/dto"
 	hh "github.com/kptm-tools/core-service/pkg/handlers"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
 	"github.com/kptm-tools/core-service/pkg/middleware"
@@ -96,7 +98,7 @@ func TestScanHandlers_GetScanAssetsByID(t *testing.T) {
 				MockGetScanAssetsByID: func(ctx context.Context, scanID uuid.UUID) ([]domain.ScanOSandServicesResult, error) {
 					return []domain.ScanOSandServicesResult{
 						{
-							AssetType:                 "host",
+							AssetType:                 "os",
 							ID:                        1,
 							HostID:                    uuid.New(),
 							ScanID:                    uuid.New(),
@@ -178,6 +180,60 @@ func TestScanHandlers_GetScanAssetsByID(t *testing.T) {
 			err := h.GetScanAssetsByID(rr, tt.r)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantStatus, rr.Code, "Expected http response code %d, got %d", tt.wantStatus, rr.Code)
+
+			// Additional validation for the "Scan Status Ok → 200" test case
+			if tt.name == "Scan Status Ok → 200" && rr.Code == http.StatusOK {
+				// Parse the response to validate vulnerability counts
+				var response dto.ScanAssetsResponse
+				err := json.Unmarshal(rr.Body.Bytes(), &response)
+				assert.NoError(t, err, "Response should be valid JSON")
+
+				// Validate OS asset counts are internally consistent
+				os := response.OperatingSystem
+				if os.ID != 0 { // OS is present
+					osSeveritySum := os.CriticalCount + os.HighCount + os.MediumCount + os.LowCount + os.NoneCount + os.UnknownCount
+					assert.Equal(t, os.TotalVulnerabilities, osSeveritySum, "OS total vulnerabilities should equal sum of severity counts")
+				}
+
+				// Validate each service asset counts are internally consistent
+				for i, svc := range response.Services {
+					svcSeveritySum := svc.CriticalCount + svc.HighCount + svc.MediumCount + svc.LowCount + svc.NoneCount + svc.UnknownCount
+					assert.Equal(t, svc.TotalVulnerabilities, svcSeveritySum, "Service %d total vulnerabilities should equal sum of severity counts", i)
+				}
+
+				// Validate that asset counts sum correctly across the scan
+				totalCritical := os.CriticalCount
+				totalHigh := os.HighCount
+				totalMedium := os.MediumCount
+				totalLow := os.LowCount
+				totalNone := os.NoneCount
+				totalUnknown := os.UnknownCount
+				totalOverall := os.TotalVulnerabilities
+
+				for _, svc := range response.Services {
+					totalCritical += svc.CriticalCount
+					totalHigh += svc.HighCount
+					totalMedium += svc.MediumCount
+					totalLow += svc.LowCount
+					totalNone += svc.NoneCount
+					totalUnknown += svc.UnknownCount
+					totalOverall += svc.TotalVulnerabilities
+				}
+
+				// Verify that the sum of all severity counts equals the total vulnerability count
+				allSeveritySum := totalCritical + totalHigh + totalMedium + totalLow + totalNone + totalUnknown
+				assert.Equal(t, totalOverall, allSeveritySum, "Sum of all severity counts should equal total vulnerabilities across all assets")
+
+				// Expected totals based on our test data:
+				// OS: 5 total (1 critical, 2 high, 1 medium, 1 low)
+				// Service: 3 total (0 critical, 1 high, 1 medium, 1 low)
+				// Total: 8 vulnerabilities
+				assert.Equal(t, 8, totalOverall, "Total vulnerabilities across all assets should match expected sum")
+				assert.Equal(t, 1, totalCritical, "Total critical vulnerabilities should match expected sum")   // 1 from OS + 0 from Service
+				assert.Equal(t, 3, totalHigh, "Total high vulnerabilities should match expected sum")         // 2 from OS + 1 from Service  
+				assert.Equal(t, 2, totalMedium, "Total medium vulnerabilities should match expected sum")     // 1 from OS + 1 from Service
+				assert.Equal(t, 2, totalLow, "Total low vulnerabilities should match expected sum")           // 1 from OS + 1 from Service
+			}
 		})
 	}
 }


### PR DESCRIPTION
This pull request refactors the SQL queries for retrieving scan assets and enhances consistency checks in the test suite. The changes improve the handling of vulnerability counts by introducing intermediate steps for combining data from different sources and ensure correctness in the test cases.

### Refactoring SQL Queries for Vulnerability Counts:
* Introduced new Common Table Expressions (CTEs) `network_vuln_counts`, `web_vuln_counts`, and `combined_service_counts` to aggregate vulnerability counts by severity for operating systems and services. This ensures a more modular and maintainable query structure. (`db/scan.sql.go`: [[1]](diffhunk://#diff-b44ba3d791fa423e51c8b9daf394679e129074fd4f5b92c9f051905bc4e791d2L60-R120) [[2]](diffhunk://#diff-b44ba3d791fa423e51c8b9daf394679e129074fd4f5b92c9f051905bc4e791d2L77-R154) [[3]](diffhunk://#diff-b44ba3d791fa423e51c8b9daf394679e129074fd4f5b92c9f051905bc4e791d2L123-R185); `db/sql/queries/scan.sql`: [[4]](diffhunk://#diff-d185fa4f891239cf1ae903619a9beb212fa6b959c40980df1efd75e595fe2776L254-R314) [[5]](diffhunk://#diff-d185fa4f891239cf1ae903619a9beb212fa6b959c40980df1efd75e595fe2776L271-R348) [[6]](diffhunk://#diff-d185fa4f891239cf1ae903619a9beb212fa6b959c40980df1efd75e595fe2776L317-R381)
* Updated `os_assets` and `service_assets` queries to use the aggregated counts from the new CTEs instead of directly calculating counts. (`db/scan.sql.go`: [[1]](diffhunk://#diff-b44ba3d791fa423e51c8b9daf394679e129074fd4f5b92c9f051905bc4e791d2L77-R154) [[2]](diffhunk://#diff-b44ba3d791fa423e51c8b9daf394679e129074fd4f5b92c9f051905bc4e791d2L123-R185); `db/sql/queries/scan.sql`: [[3]](diffhunk://#diff-d185fa4f891239cf1ae903619a9beb212fa6b959c40980df1efd75e595fe2776L271-R348) [[4]](diffhunk://#diff-d185fa4f891239cf1ae903619a9beb212fa6b959c40980df1efd75e595fe2776L317-R381)

### Enhancing Test Coverage:
* Added detailed validation in the test case `TestScanHandlers_GetScanAssetsByID` to ensure that total vulnerability counts and severity counts are consistent at both the individual asset and overall scan levels. (`pkg/handlers/scan_test.go`: [pkg/handlers/scan_test.goR183-R236](diffhunk://#diff-315ad6e8da787f45a28c99f518ec2b0a64dd1e867c0d1fe783d910ac70be6b00R183-R236))
* Updated mock data in the test case to reflect the new asset type naming convention (`os` instead of `host`). (`pkg/handlers/scan_test.go`: [pkg/handlers/scan_test.goL99-R101](diffhunk://#diff-315ad6e8da787f45a28c99f518ec2b0a64dd1e867c0d1fe783d910ac70be6b00L99-R101))

### Minor Fixes:
* Corrected a typo in the JSON field name from `remediation` to `remediations` in response DTOs for consistency. (`pkg/dto/response.go`: [[1]](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL268-R268) [[2]](diffhunk://#diff-0d99b2d3c340760e1a0dd3d7c371c0eddcefac32030f16ff08e268f2a7e9c00cL286-R286)
* Added missing imports (`encoding/json` and `dto`) in the test file to support new validation logic. (`pkg/handlers/scan_test.go`: [[1]](diffhunk://#diff-315ad6e8da787f45a28c99f518ec2b0a64dd1e867c0d1fe783d910ac70be6b00R5) [[2]](diffhunk://#diff-315ad6e8da787f45a28c99f518ec2b0a64dd1e867c0d1fe783d910ac70be6b00R15)