### PR TITLE
KT-531: VulnByService API Endpoint Enhancement

### DIFF
--- a/db/sql/queries/vulnerability.sql
+++ b/db/sql/queries/vulnerability.sql
@@ -148,20 +148,64 @@ LEFT JOIN vulnerabilities v
 WHERE nov.service_id IS NOT NULL 
   AND v.scan_id = $1;
 
--- name: GetNetworkOSServicesVulnerabilityCountsByScanAndServiceID :one
-SELECT 
+-- name: GetVulnerabilitySeverityCountsByScanAndServiceID :one
+WITH network_vuln_counts AS (
+    -- Step 1: Count vulnerabilities linked via the network_os_vulnerabilities table (for specific Service)
+    SELECT
+        nov.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+FROM
+    vulnerabilities v
+    JOIN
+    network_os_vulnerabilities nov ON v.id = nov.vulnerability_id
+WHERE
+    v.scan_id = $1 and nov.service_id=$2
+GROUP BY nov.service_id
+    ),
+    web_vuln_counts AS (
+-- Step 2: Count vulnerabilities linked via the web_vulnerabilities table (for specific service)
+SELECT
+    wv.service_id,
     COUNT(v.id) AS total_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS integer) AS unknown_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END), 0) AS integer) AS none_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END), 0) AS integer) AS low_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END), 0) AS integer) as medium_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END), 0) AS integer) as high_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END), 0) AS integer) AS critical_vulnerabilities
-FROM network_os_vulnerabilities nov
-LEFT JOIN vulnerabilities v 
-    ON nov.vulnerability_id = v.id
-WHERE nov.service_id IS NOT NULL 
-  AND v.scan_id = $1 AND nov.service_id = $2;
+    SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+    SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+    SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+    SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+    SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+    SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+FROM
+    vulnerabilities v
+    JOIN
+    web_vulnerabilities wv ON v.id = wv.vulnerability_id
+WHERE
+    v.scan_id = $1 and wv.service_id= $2
+GROUP BY wv.service_id
+    ),
+    combined_service_counts AS (
+-- Step 3: Combine the counts for specific service, as they can have both network and web vulns.
+SELECT
+    COALESCE(nvc.service_id, wvc.service_id) AS service_id,
+    COALESCE(nvc.total_vulnerabilities, 0) + COALESCE(wvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+    COALESCE(nvc.critical, 0) + COALESCE(wvc.critical, 0) AS critical_count,
+    COALESCE(nvc.high, 0) + COALESCE(wvc.high, 0) AS high_count,
+    COALESCE(nvc.medium, 0) + COALESCE(wvc.medium, 0) AS medium_count,
+    COALESCE(nvc.low, 0) + COALESCE(wvc.low, 0) AS low_count,
+    COALESCE(nvc.none, 0) + COALESCE(wvc.none, 0) AS none_count,
+    COALESCE(nvc.unknown, 0) + COALESCE(wvc.unknown, 0) AS unknown_count
+FROM
+    network_vuln_counts nvc
+    FULL OUTER JOIN
+    web_vuln_counts wvc ON nvc.service_id = wvc.service_id
+WHERE
+    nvc.service_id IS NOT NULL OR wvc.service_id IS NOT NULL
+    )
+SELECT * FROM combined_service_counts;
 
 -- name: GetVulnerabilityCategoriesByScan :many
 SELECT

--- a/db/sql/queries/web_vulnerability.sql
+++ b/db/sql/queries/web_vulnerability.sql
@@ -26,9 +26,9 @@ FROM web_vulnerabilities
 WHERE scan_id = $1;
 
 -- name: ListWebVulnerabilitiesByServiceID :many
-SELECT I.uri, I.method, I.param, I.evidence, I.other_info, I.attack, W.vulnerability_id, W.scan_id, W.host_id, W.service_id, W.solution_advice, W.reference, W.created_at, W.updated_at
+SELECT I.uri, I.method, I.param, I.evidence, I.other_info, I.attack, W.vulnerability_id, W.scan_id, W.host_id, W.service_id, W.solution_advice, W.reference, W.created_at, W.updated_at, V.title, V.severity
 FROM (SELECT * FROM web_vulnerabilities WHERE service_id=$1) W
-INNER JOIN (SELECT id FROM vulnerabilities WHERE vuln_type ='WEB_APPLICATION') V
+INNER JOIN (SELECT id, title, severity FROM vulnerabilities WHERE vuln_type ='WEB_APPLICATION') V
 ON W.vulnerability_id=V.id
 LEFT JOIN web_vulnerability_instances I ON W.vulnerability_id=I.source_vulnerability_id;
 

--- a/db/vulnerability.sql.go
+++ b/db/vulnerability.sql.go
@@ -135,52 +135,6 @@ func (q *Queries) DeleteVulnerabilityComment(ctx context.Context, id uuid.UUID) 
 	return i, err
 }
 
-const getNetworkOSServicesVulnerabilityCountsByScanAndServiceID = `-- name: GetNetworkOSServicesVulnerabilityCountsByScanAndServiceID :one
-SELECT 
-    COUNT(v.id) AS total_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS integer) AS unknown_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END), 0) AS integer) AS none_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END), 0) AS integer) AS low_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END), 0) AS integer) as medium_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END), 0) AS integer) as high_vulnerabilities,
-    CAST(COALESCE(SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END), 0) AS integer) AS critical_vulnerabilities
-FROM network_os_vulnerabilities nov
-LEFT JOIN vulnerabilities v 
-    ON nov.vulnerability_id = v.id
-WHERE nov.service_id IS NOT NULL 
-  AND v.scan_id = $1 AND nov.service_id = $2
-`
-
-type GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDParams struct {
-	ScanID    uuid.UUID     `json:"scan_id"`
-	ServiceID sql.NullInt32 `json:"service_id"`
-}
-
-type GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDRow struct {
-	TotalVulnerabilities    int64 `json:"total_vulnerabilities"`
-	UnknownVulnerabilities  int32 `json:"unknown_vulnerabilities"`
-	NoneVulnerabilities     int32 `json:"none_vulnerabilities"`
-	LowVulnerabilities      int32 `json:"low_vulnerabilities"`
-	MediumVulnerabilities   int32 `json:"medium_vulnerabilities"`
-	HighVulnerabilities     int32 `json:"high_vulnerabilities"`
-	CriticalVulnerabilities int32 `json:"critical_vulnerabilities"`
-}
-
-func (q *Queries) GetNetworkOSServicesVulnerabilityCountsByScanAndServiceID(ctx context.Context, arg GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDParams) (GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getNetworkOSServicesVulnerabilityCountsByScanAndServiceID, arg.ScanID, arg.ServiceID)
-	var i GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDRow
-	err := row.Scan(
-		&i.TotalVulnerabilities,
-		&i.UnknownVulnerabilities,
-		&i.NoneVulnerabilities,
-		&i.LowVulnerabilities,
-		&i.MediumVulnerabilities,
-		&i.HighVulnerabilities,
-		&i.CriticalVulnerabilities,
-	)
-	return i, err
-}
-
 const getNetworkOSServicesVulnerabilityCountsByScanID = `-- name: GetNetworkOSServicesVulnerabilityCountsByScanID :one
 SELECT 
     COUNT(v.id) AS total_vulnerabilities,
@@ -660,6 +614,98 @@ func (q *Queries) GetVulnerabilityNetworkOSSeverityCountsByScanID(ctx context.Co
 		&i.MediumVulnerabilities,
 		&i.HighVulnerabilities,
 		&i.CriticalVulnerabilities,
+	)
+	return i, err
+}
+
+const getVulnerabilitySeverityCountsByScanAndServiceID = `-- name: GetVulnerabilitySeverityCountsByScanAndServiceID :one
+WITH network_vuln_counts AS (
+    -- Step 1: Count vulnerabilities linked via the network_os_vulnerabilities table (for specific Service)
+    SELECT
+        nov.service_id,
+        COUNT(v.id) AS total_vulnerabilities,
+        SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+        SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+        SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+        SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+        SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+        SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+FROM
+    vulnerabilities v
+    JOIN
+    network_os_vulnerabilities nov ON v.id = nov.vulnerability_id
+WHERE
+    v.scan_id = $1 and nov.service_id=$2
+GROUP BY nov.service_id
+    ),
+    web_vuln_counts AS (
+SELECT
+    wv.service_id,
+    COUNT(v.id) AS total_vulnerabilities,
+    SUM(CASE WHEN v.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS critical,
+    SUM(CASE WHEN v.severity = 'HIGH' THEN 1 ELSE 0 END) AS high,
+    SUM(CASE WHEN v.severity = 'MEDIUM' THEN 1 ELSE 0 END) AS medium,
+    SUM(CASE WHEN v.severity = 'LOW' THEN 1 ELSE 0 END) AS low,
+    SUM(CASE WHEN v.severity = 'NONE' THEN 1 ELSE 0 END) AS none,
+    SUM(CASE WHEN v.severity = 'UNKNOWN' THEN 1 ELSE 0 END) AS unknown
+FROM
+    vulnerabilities v
+    JOIN
+    web_vulnerabilities wv ON v.id = wv.vulnerability_id
+WHERE
+    v.scan_id = $1 and wv.service_id= $2
+GROUP BY wv.service_id
+    ),
+    combined_service_counts AS (
+SELECT
+    COALESCE(nvc.service_id, wvc.service_id) AS service_id,
+    COALESCE(nvc.total_vulnerabilities, 0) + COALESCE(wvc.total_vulnerabilities, 0) AS total_vulnerabilities_count,
+    COALESCE(nvc.critical, 0) + COALESCE(wvc.critical, 0) AS critical_count,
+    COALESCE(nvc.high, 0) + COALESCE(wvc.high, 0) AS high_count,
+    COALESCE(nvc.medium, 0) + COALESCE(wvc.medium, 0) AS medium_count,
+    COALESCE(nvc.low, 0) + COALESCE(wvc.low, 0) AS low_count,
+    COALESCE(nvc.none, 0) + COALESCE(wvc.none, 0) AS none_count,
+    COALESCE(nvc.unknown, 0) + COALESCE(wvc.unknown, 0) AS unknown_count
+FROM
+    network_vuln_counts nvc
+    FULL OUTER JOIN
+    web_vuln_counts wvc ON nvc.service_id = wvc.service_id
+WHERE
+    nvc.service_id IS NOT NULL OR wvc.service_id IS NOT NULL
+    )
+SELECT service_id, total_vulnerabilities_count, critical_count, high_count, medium_count, low_count, none_count, unknown_count FROM combined_service_counts
+`
+
+type GetVulnerabilitySeverityCountsByScanAndServiceIDParams struct {
+	ScanID    uuid.UUID     `json:"scan_id"`
+	ServiceID sql.NullInt32 `json:"service_id"`
+}
+
+type GetVulnerabilitySeverityCountsByScanAndServiceIDRow struct {
+	ServiceID                 int32 `json:"service_id"`
+	TotalVulnerabilitiesCount int32 `json:"total_vulnerabilities_count"`
+	CriticalCount             int32 `json:"critical_count"`
+	HighCount                 int32 `json:"high_count"`
+	MediumCount               int32 `json:"medium_count"`
+	LowCount                  int32 `json:"low_count"`
+	NoneCount                 int32 `json:"none_count"`
+	UnknownCount              int32 `json:"unknown_count"`
+}
+
+// Step 2: Count vulnerabilities linked via the web_vulnerabilities table (for specific service)
+// Step 3: Combine the counts for specific service, as they can have both network and web vulns.
+func (q *Queries) GetVulnerabilitySeverityCountsByScanAndServiceID(ctx context.Context, arg GetVulnerabilitySeverityCountsByScanAndServiceIDParams) (GetVulnerabilitySeverityCountsByScanAndServiceIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getVulnerabilitySeverityCountsByScanAndServiceID, arg.ScanID, arg.ServiceID)
+	var i GetVulnerabilitySeverityCountsByScanAndServiceIDRow
+	err := row.Scan(
+		&i.ServiceID,
+		&i.TotalVulnerabilitiesCount,
+		&i.CriticalCount,
+		&i.HighCount,
+		&i.MediumCount,
+		&i.LowCount,
+		&i.NoneCount,
+		&i.UnknownCount,
 	)
 	return i, err
 }

--- a/db/web_vulnerability.sql.go
+++ b/db/web_vulnerability.sql.go
@@ -171,9 +171,9 @@ func (q *Queries) ListWebVulnerabilitiesByScanID(ctx context.Context, scanID uui
 }
 
 const listWebVulnerabilitiesByServiceID = `-- name: ListWebVulnerabilitiesByServiceID :many
-SELECT I.uri, I.method, I.param, I.evidence, I.other_info, I.attack, W.vulnerability_id, W.scan_id, W.host_id, W.service_id, W.solution_advice, W.reference, W.created_at, W.updated_at
+SELECT I.uri, I.method, I.param, I.evidence, I.other_info, I.attack, W.vulnerability_id, W.scan_id, W.host_id, W.service_id, W.solution_advice, W.reference, W.created_at, W.updated_at, V.title, V.severity
 FROM (SELECT vulnerability_id, scan_id, host_id, service_id, solution_advice, reference, created_at, updated_at, wasc_id FROM web_vulnerabilities WHERE service_id=$1) W
-INNER JOIN (SELECT id FROM vulnerabilities WHERE vuln_type ='WEB_APPLICATION') V
+INNER JOIN (SELECT id, title, severity FROM vulnerabilities WHERE vuln_type ='WEB_APPLICATION') V
 ON W.vulnerability_id=V.id
 LEFT JOIN web_vulnerability_instances I ON W.vulnerability_id=I.source_vulnerability_id
 `
@@ -193,6 +193,8 @@ type ListWebVulnerabilitiesByServiceIDRow struct {
 	Reference       sql.NullString `json:"reference"`
 	CreatedAt       sql.NullTime   `json:"created_at"`
 	UpdatedAt       sql.NullTime   `json:"updated_at"`
+	Title           string         `json:"title"`
+	Severity        string         `json:"severity"`
 }
 
 func (q *Queries) ListWebVulnerabilitiesByServiceID(ctx context.Context, serviceID int32) ([]ListWebVulnerabilitiesByServiceIDRow, error) {
@@ -219,6 +221,8 @@ func (q *Queries) ListWebVulnerabilitiesByServiceID(ctx context.Context, service
 			&i.Reference,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Title,
+			&i.Severity,
 		); err != nil {
 			return nil, err
 		}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -687,6 +687,9 @@ const docTemplate = `{
                 "evidence": {
                     "type": "string"
                 },
+                "id": {
+                    "type": "string"
+                },
                 "method": {
                     "type": "string"
                 },
@@ -694,6 +697,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "param": {
+                    "type": "string"
+                },
+                "source_vulnerability_id": {
                     "type": "string"
                 },
                 "uri": {
@@ -939,7 +945,7 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "remediation": {
+                "remediations": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation"
@@ -974,7 +980,7 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "remediation": {
+                "remediations": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation"
@@ -1007,7 +1013,7 @@ const docTemplate = `{
                 "service_protocol": {
                     "type": "string"
                 },
-                "service_verion": {
+                "service_version": {
                     "type": "string"
                 },
                 "severity_counts": {
@@ -1020,6 +1026,12 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.ScanVulnerabilityItem"
+                    }
+                },
+                "web_vulnerabilities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary"
                     }
                 }
             }
@@ -1120,6 +1132,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wasc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "instances_count": {
+                    "type": "integer"
+                },
+                "scan_id": {
+                    "type": "string"
+                },
+                "service_id": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "vulnerability_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -676,6 +676,9 @@
                 "evidence": {
                     "type": "string"
                 },
+                "id": {
+                    "type": "string"
+                },
                 "method": {
                     "type": "string"
                 },
@@ -683,6 +686,9 @@
                     "type": "string"
                 },
                 "param": {
+                    "type": "string"
+                },
+                "source_vulnerability_id": {
                     "type": "string"
                 },
                 "uri": {
@@ -928,7 +934,7 @@
                         "type": "string"
                     }
                 },
-                "remediation": {
+                "remediations": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation"
@@ -963,7 +969,7 @@
                         "type": "string"
                     }
                 },
-                "remediation": {
+                "remediations": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation"
@@ -996,7 +1002,7 @@
                 "service_protocol": {
                     "type": "string"
                 },
-                "service_verion": {
+                "service_version": {
                     "type": "string"
                 },
                 "severity_counts": {
@@ -1009,6 +1015,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.ScanVulnerabilityItem"
+                    }
+                },
+                "web_vulnerabilities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary"
                     }
                 }
             }
@@ -1109,6 +1121,32 @@
                     "type": "string"
                 },
                 "wasc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary": {
+            "type": "object",
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "instances_count": {
+                    "type": "integer"
+                },
+                "scan_id": {
+                    "type": "string"
+                },
+                "service_id": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "vulnerability_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -266,11 +266,15 @@ definitions:
         type: string
       evidence:
         type: string
+      id:
+        type: string
       method:
         type: string
       other_info:
         type: string
       param:
+        type: string
+      source_vulnerability_id:
         type: string
       uri:
         type: string
@@ -470,7 +474,7 @@ definitions:
         items:
           type: string
         type: array
-      remediation:
+      remediations:
         items:
           $ref: '#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation'
         type: array
@@ -493,7 +497,7 @@ definitions:
         items:
           type: string
         type: array
-      remediation:
+      remediations:
         items:
           $ref: '#/definitions/github_com_kptm-tools_core-service_pkg_dto.CWERemediation'
         type: array
@@ -515,7 +519,7 @@ definitions:
         type: string
       service_protocol:
         type: string
-      service_verion:
+      service_version:
         type: string
       severity_counts:
         $ref: '#/definitions/tools.SeverityCounts'
@@ -524,6 +528,10 @@ definitions:
       vulnerabilities:
         items:
           $ref: '#/definitions/github_com_kptm-tools_core-service_pkg_dto.ScanVulnerabilityItem'
+        type: array
+      web_vulnerabilities:
+        items:
+          $ref: '#/definitions/github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary'
         type: array
     type: object
   github_com_kptm-tools_core-service_pkg_dto.ScanVulnerabilityItem:
@@ -590,6 +598,23 @@ definitions:
       vulnerability_id:
         type: string
       wasc_id:
+        type: string
+    type: object
+  github_com_kptm-tools_core-service_pkg_dto.WebVulnerabilitySummary:
+    properties:
+      host_id:
+        type: string
+      instances_count:
+        type: integer
+      scan_id:
+        type: string
+      service_id:
+        type: string
+      severity:
+        type: string
+      title:
+        type: string
+      vulnerability_id:
         type: string
     type: object
   tools.SeverityCounts:

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -161,6 +161,8 @@ type WebVulnerability struct {
 	Instances       []WebVulnerabilityInstance `json:"instances"`
 	CweID           string                     `json:"cwe_id,omitempty"`
 	WascID          string                     `json:"wasc_id,omitempty"`
+	Title           string                     `json:"title"`
+	Severity        string                     `json:"severity"`
 }
 
 type WebVulnerabilityInstance struct {

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -303,6 +303,8 @@ func CountSeverityOccurrencesGeneric[T SeverityProvider](vulnerabilities []T) to
 			counts.None++
 		case enums.SeverityTypeUnknown.String():
 			counts.Unknown++
+		default:
+			counts.Unknown++
 		}
 	}
 

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -301,7 +301,7 @@ func CountSeverityOccurrencesGeneric[T SeverityProvider](vulnerabilities []T) to
 			counts.Low++
 		case enums.SeverityTypeNone.String():
 			counts.None++
-		default:
+		case enums.SeverityTypeUnknown.String():
 			counts.Unknown++
 		}
 	}

--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -284,7 +284,7 @@ type ScanVulnerabilityDetectedServiceResponse struct {
 	ScanID               string                    `json:"scan_id"`
 	ScanDate             time.Time                 `json:"scan_date"`
 	ServiceName          string                    `json:"service_name"`
-	ServiceVersion       string                    `json:"service_verion"`
+	ServiceVersion       string                    `json:"service_version"`
 	ServiceConfidence    int32                     `json:"service_confidence"`
 	ServiceCPE           string                    `json:"service_cpe"`
 	ServiceProduct       string                    `json:"service_product"`

--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -777,8 +777,8 @@ func ConvertToWebVulnSummaryToResponse(results []domain.WebVulnerability) []WebV
 			ScanID:          r.ScanID.String(),
 			HostID:          r.HostID.String(),
 			ServiceID:       strconv.Itoa(int(r.ServiceID)),
-			Title:           "",
-			Severity:        "",
+			Title:           r.Title,
+			Severity:        r.Severity,
 			InstancesCount:  len(r.Instances),
 		}
 	}

--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -270,22 +270,33 @@ type ScanVulnerabilityDetectedOSResponse struct {
 	References           []string                `json:"references"`
 }
 
+type WebVulnerabilitySummary struct {
+	VulnerabilityID string `json:"vulnerability_id"`
+	ScanID          string `json:"scan_id"`
+	HostID          string `json:"host_id"`
+	ServiceID       string `json:"service_id"`
+	Title           string `json:"title"`
+	Severity        string `json:"severity"`
+	InstancesCount  int    `json:"instances_count"`
+}
+
 type ScanVulnerabilityDetectedServiceResponse struct {
-	ScanID               string                  `json:"scan_id"`
-	ScanDate             time.Time               `json:"scan_date"`
-	ServiceName          string                  `json:"service_name"`
-	ServiceVersion       string                  `json:"service_verion"`
-	ServiceConfidence    int32                   `json:"service_confidence"`
-	ServiceCPE           string                  `json:"service_cpe"`
-	ServiceProduct       string                  `json:"service_product"`
-	ServiceProtocol      string                  `json:"service_protocol"`
-	ServicePort          int                     `json:"service_port"`
-	ServicePortState     string                  `json:"service_port_state"`
-	TotalVulnerabilities int                     `json:"total_vulnerabilities"`
-	SeverityCounts       tools.SeverityCounts    `json:"severity_counts"`
-	Vulnerabilities      []ScanVulnerabilityItem `json:"vulnerabilities"`
-	CWERemediations      []CWERemediation        `json:"remediations"`
-	References           []string                `json:"references"`
+	ScanID               string                    `json:"scan_id"`
+	ScanDate             time.Time                 `json:"scan_date"`
+	ServiceName          string                    `json:"service_name"`
+	ServiceVersion       string                    `json:"service_verion"`
+	ServiceConfidence    int32                     `json:"service_confidence"`
+	ServiceCPE           string                    `json:"service_cpe"`
+	ServiceProduct       string                    `json:"service_product"`
+	ServiceProtocol      string                    `json:"service_protocol"`
+	ServicePort          int                       `json:"service_port"`
+	ServicePortState     string                    `json:"service_port_state"`
+	TotalVulnerabilities int                       `json:"total_vulnerabilities"`
+	SeverityCounts       tools.SeverityCounts      `json:"severity_counts"`
+	Vulnerabilities      []ScanVulnerabilityItem   `json:"vulnerabilities"`
+	CWERemediations      []CWERemediation          `json:"remediations"`
+	References           []string                  `json:"references"`
+	WebVulnerabilities   []WebVulnerabilitySummary `json:"web_vulnerabilities"`
 }
 
 type ScanVulnerabilityItem struct {
@@ -756,4 +767,20 @@ func ConvertDomWebVulnToDtoWebVuln(vulnerability domain.WebVulnerability) ScanWe
 		CweID:          vulnerability.CweID,
 		WascID:         vulnerability.WascID,
 	}
+}
+
+func ConvertToWebVulnSummaryToResponse(results []domain.WebVulnerability) []WebVulnerabilitySummary {
+	summaries := make([]WebVulnerabilitySummary, len(results))
+	for i, r := range results {
+		summaries[i] = WebVulnerabilitySummary{
+			VulnerabilityID: r.VulnerabilityID.String(),
+			ScanID:          r.ScanID.String(),
+			HostID:          r.HostID.String(),
+			ServiceID:       strconv.Itoa(int(r.ServiceID)),
+			Title:           "",
+			Severity:        "",
+			InstancesCount:  len(r.Instances),
+		}
+	}
+	return summaries
 }

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -724,12 +724,16 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 	}
 
 	if len(vulnerabilities) == 0 && len(webVulns) == 0 {
-		slog.Warn("No vulnerabilities no web and web found for scan",
+		slog.Warn("There are no vulnerabilities for scan",
 			slog.String("scan_id", scanID.String()),
 			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
 		)
 		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{})
 	} else if len(vulnerabilities) == 0 && len(webVulns) > 0 {
+		slog.Warn("There are only web vulnerabilities for scan",
+			slog.String("scan_id", scanID.String()),
+			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
+		)
 		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{
 			WebVulnerabilities: dto.ConvertToWebVulnSummaryToResponse(webVulns),
 		})

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -714,19 +714,30 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 		})
 	}
 
-	if len(vulnerabilities) == 0 {
-		slog.Warn("No vulnerabilities found for scan",
+	webVulns, errWebVulns := h.vulnService.GetWebVulnerabilitiesForService(ctx, serviceID)
+
+	if errWebVulns != nil {
+		slog.Error("Failed to fetch scan vulnerabilities", slog.Any("error", errWebVulns))
+		return api.WriteJSON(w, http.StatusInternalServerError, api.APIError{
+			Error: http.StatusText(http.StatusInternalServerError),
+		})
+	}
+
+	if len(vulnerabilities) == 0 && len(webVulns) == 0 {
+		slog.Warn("No vulnerabilities no web and web found for scan",
 			slog.String("scan_id", scanID.String()),
 			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
 		)
 		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{})
+	} else if len(vulnerabilities) == 0 && len(webVulns) > 0 {
+		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{
+			WebVulnerabilities: dto.ConvertToWebVulnSummaryToResponse(webVulns),
+		})
 	}
-
-	webVulns, err := h.vulnService.GetWebVulnerabilitiesForService(ctx, serviceID)
 
 	serviceDetail, err := h.vulnService.GetServiceByID(ctx, serviceID)
 	if err != nil {
-		slog.Error("Failed to fetch severity counts",
+		slog.Error("Failed to fetch service detail",
 			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
 			slog.Any("error", err),
 		)

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -722,6 +722,8 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{})
 	}
 
+	webVulns, err := h.vulnService.GetWebVulnerabilitiesForService(ctx, serviceID)
+
 	serviceDetail, err := h.vulnService.GetServiceByID(ctx, serviceID)
 	if err != nil {
 		slog.Error("Failed to fetch severity counts",
@@ -811,6 +813,7 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 		TotalVulnerabilities: severityCounts.Critical + severityCounts.High + severityCounts.Medium + severityCounts.Low + severityCounts.None + severityCounts.Unknown,
 		SeverityCounts:       severityCounts,
 		Vulnerabilities:      scanVulnerabilityItems,
+		WebVulnerabilities:   dto.ConvertToWebVulnSummaryToResponse(webVulns),
 		CWERemediations:      totalRemediations,
 		References:           totalReferences,
 	}

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -723,22 +724,6 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 		})
 	}
 
-	if len(vulnerabilities) == 0 && len(webVulns) == 0 {
-		slog.Warn("There are no vulnerabilities for scan",
-			slog.String("scan_id", scanID.String()),
-			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
-		)
-		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{})
-	} else if len(vulnerabilities) == 0 && len(webVulns) > 0 {
-		slog.Warn("There are only web vulnerabilities for scan",
-			slog.String("scan_id", scanID.String()),
-			slog.String("service_id", fmt.Sprintf("%d", serviceID)),
-		)
-		return api.WriteJSON(w, http.StatusOK, dto.ScanVulnerabilityDetectedServiceResponse{
-			WebVulnerabilities: dto.ConvertToWebVulnSummaryToResponse(webVulns),
-		})
-	}
-
 	serviceDetail, err := h.vulnService.GetServiceByID(ctx, serviceID)
 	if err != nil {
 		slog.Error("Failed to fetch service detail",
@@ -752,6 +737,12 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 
 	severityCounts, err := h.scanService.GetSeverityServiceCountsByScanAndServiceID(ctx, scanID, serviceID)
 	if err != nil {
+		if errors.Is(err, customerrors.ErrScanNotFound) {
+			slog.Error("Service not found for scanID", slog.String("scan_id", scanID.String()), slog.String("service_id", strconv.Itoa(int(serviceID))))
+			return api.WriteJSON(w, http.StatusNotFound, api.APIError{
+				Error: "Service not found for scanID",
+			})
+		}
 		slog.Error("Failed to fetch severity counts",
 			slog.String("scan_id", scanID.String()),
 			slog.Any("error", err),
@@ -816,7 +807,7 @@ func (h *ScanHandlers) GetScanServicesVulnerabilitiesByServiceID(w http.Response
 	// Aggregate response object
 	response := dto.ScanVulnerabilityDetectedServiceResponse{
 		ScanID:               scanID.String(),
-		ScanDate:             vulnerabilities[0].ScanDate,
+		ScanDate:             scan.CreatedAt,
 		ServiceName:          serviceDetail.SvName,
 		ServiceVersion:       serviceDetail.SvVersion,
 		ServiceConfidence:    serviceDetail.Confidence,

--- a/pkg/handlers/scan.go
+++ b/pkg/handlers/scan.go
@@ -623,7 +623,7 @@ func (h *ScanHandlers) GetScanOperatingSystemVulnerabilitiesByID(w http.Response
 		Vulnerabilities:      scanVulnerabilityItems,
 		CWERemediations:      totalRemediations,
 		References:           totalReferences,
-		TotalVulnerabilities: severityCounts.Critical + severityCounts.High + severityCounts.Medium + severityCounts.Low,
+		TotalVulnerabilities: severityCounts.Critical + severityCounts.High + severityCounts.Medium + severityCounts.Low + severityCounts.None + severityCounts.Unknown,
 		SeverityCounts:       severityCounts,
 	}
 

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -569,7 +569,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{},
 		},
 		{
-			name: "ScanID exists but Not ServiceID for that Scan → 404",
+			name: "Service not found for scan → 404",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{Status: "Completed"}, nil
@@ -606,7 +606,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{"Service not found for scanID"},
 		},
 		{
-			name: "Error in Get Not Web Vulnerabilities → 500",
+			name: "Error Getting Service Vulnerability Details → 500",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{Status: "Completed"}, nil
@@ -668,7 +668,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{},
 		},
 		{
-			name: "Empty for No Web and web Vulnerabilities → 200",
+			name: "No vulnerabilities returns empty response → 200",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{Status: "Completed"}, nil
@@ -703,7 +703,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{},
 		},
 		{
-			name: "Empty for No Web Vulnerabilities but not empty for web→ 200",
+			name: "Service with only web vulnerabilities returns partial data → 200",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{
@@ -753,7 +753,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{"http", scanID.String(), scanDate.Format("2006-01-02T15:04:05")},
 		},
 		{
-			name: "Error in serviceID detail→ 500",
+			name: "Error in serviceID detail → 500",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{Status: "Completed"}, nil

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 
-	//"github.com/kptm-tools/core-service/pkg/customerrors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -589,7 +588,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			emailService:        &mock_services.MockEmailService{},
 			eventBus:            &events.NatsEventBus{},
 			r: func() *http.Request {
-				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/invalid/vulnerabilities", nil)
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
 				r.SetPathValue("id", scanID.String())
 				r.SetPathValue("service_id", strconv.Itoa(serviceID))
 				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -471,6 +471,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 	titleWebVuln := "Cross Site Scripting (Reflected)"
 	titleVuln := "CVE-2024-5985"
 	mitigationID := "MIT-1"
+	scanDate := time.Now()
 	tests := []struct {
 		name                string
 		scanService         interfaces.IScanService
@@ -635,6 +636,9 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
 					return &domain.Scan{Status: "Completed"}, nil
 				},
+				MockGetSeverityServiceCountsByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
+					return tools.SeverityCounts{}, nil
+				},
 			},
 			vulnService: &mock_services.MockVulnerabilityService{
 				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
@@ -665,7 +669,18 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			name: "Empty for No Web Vulnerabilities but not empty for web→ 200",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
-					return &domain.Scan{Status: "Completed"}, nil
+					return &domain.Scan{
+						ID:        scanID,
+						CreatedAt: scanDate,
+						Status:    "Completed"}, nil
+				},
+				MockGetSeverityServiceCountsByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
+					return tools.SeverityCounts{
+						Critical: 1,
+						High:     2,
+						Medium:   3,
+						Low:      4,
+					}, nil
 				},
 			},
 			vulnService: &mock_services.MockVulnerabilityService{
@@ -680,7 +695,9 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 					}, nil
 				},
 				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
-					return &domain.Service{}, nil
+					return &domain.Service{
+						SvName: "http",
+					}, nil
 				},
 			},
 			scanScheduleService: &mock_services.MockScanScheduleService{},
@@ -694,8 +711,9 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
 				return r
 			}(),
-			wantStatus:       http.StatusOK,
-			wantBodyContains: []string{},
+			wantStatus: http.StatusOK,
+			// Ensure that we return service and scan metadata
+			wantBodyContains: []string{"http", scanID.String(), scanDate.Format("2006-01-02T15:04:05.000000-07:00")},
 		},
 		{
 			name: "Error in serviceID detail→ 500",

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -569,6 +569,43 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			wantBodyContains: []string{},
 		},
 		{
+			name: "ScanID exists but Not ServiceID for that Scan → 404",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+				MockGetSeverityServiceCountsByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
+					return tools.SeverityCounts{}, customerrors.ErrScanNotFound
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{
+						ID: serviceID,
+					}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusNotFound,
+			wantBodyContains: []string{"Service not found for scanID"},
+		},
+		{
 			name: "Error in Get Not Web Vulnerabilities → 500",
 			scanService: &mock_services.MockScanService{
 				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/core-service/pkg/customerrors"
 
 	//"github.com/kptm-tools/core-service/pkg/customerrors"
@@ -468,7 +469,9 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 	scanID := uuid.New()
 	vulnID := uuid.New()
 	serviceID := 42
-
+	titleWebVuln := "Cross Site Scripting (Reflected)"
+	titleVuln := "CVE-2024-5985"
+	mitigationID := "MIT-1"
 	tests := []struct {
 		name                string
 		scanService         interfaces.IScanService
@@ -798,7 +801,14 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
 					return []domain.ScanVulnerabilityDetail{
 						{
-							ID: vulnID,
+							ID:   vulnID,
+							Name: titleVuln,
+							CWERemediation: []tools.CWERemediation{
+								{
+									MitigationID: mitigationID,
+									Description:  "Example mitigation description",
+								},
+							},
 						},
 					}, nil
 				},
@@ -806,6 +816,17 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 					return []domain.WebVulnerability{
 						{
 							VulnerabilityID: vulnID,
+							ServiceID:       serviceID,
+							Title:           "Cross Site Scripting (Reflected)",
+							Severity:        enums.SeverityTypeHigh.String(),
+							Instances: []domain.WebVulnerabilityInstance{
+								{
+									URI: "url1",
+								},
+								{
+									URI: "url2",
+								},
+							},
 						},
 					}, nil
 				},
@@ -827,7 +848,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 				return r
 			}(),
 			wantStatus:       http.StatusOK,
-			wantBodyContains: []string{"http"},
+			wantBodyContains: []string{"http", "HIGH"},
 		},
 	}
 
@@ -859,9 +880,12 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 				assert.Equal(t, 2, resp.SeverityCounts.High)
 				assert.Equal(t, 3, resp.SeverityCounts.Medium)
 				assert.Equal(t, 4, resp.SeverityCounts.Low)
-				//assert.Equal(t, "CVE-2024-0001", resp.Vulnerabilities[0].Name)
-				//assert.Equal(t, "Remediation description", resp.CWERemediations[0].Description)
-				//assert.Equal(t, "WebVuln", resp.WebVulnerabilities[0].Name)
+				assert.Equal(t, titleVuln, resp.Vulnerabilities[0].Name)
+				assert.Equal(t, mitigationID, *resp.CWERemediations[0].MitigationID)
+				assert.Equal(t, 2, resp.WebVulnerabilities[0].InstancesCount)
+				assert.Equal(t, strconv.Itoa(serviceID), resp.WebVulnerabilities[0].ServiceID)
+				assert.Equal(t, titleWebVuln, resp.WebVulnerabilities[0].Title)
+				assert.Equal(t, enums.SeverityTypeHigh.String(), resp.WebVulnerabilities[0].Severity)
 			}
 		})
 	}

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -713,7 +713,7 @@ func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
 			}(),
 			wantStatus: http.StatusOK,
 			// Ensure that we return service and scan metadata
-			wantBodyContains: []string{"http", scanID.String(), scanDate.Format("2006-01-02T15:04:05.000000-07:00")},
+			wantBodyContains: []string{"http", scanID.String(), scanDate.Format("2006-01-02T15:04:05")},
 		},
 		{
 			name: "Error in serviceID detail→ 500",

--- a/pkg/handlers/scan_test.go
+++ b/pkg/handlers/scan_test.go
@@ -3,8 +3,13 @@ package handlers_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"github.com/kptm-tools/core-service/pkg/customerrors"
+
+	//"github.com/kptm-tools/core-service/pkg/customerrors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -455,6 +460,409 @@ func TestScanHandlers_GetScanOperatingSystemVulnerabilitiesByID(t *testing.T) {
 			err := h.GetScanOperatingSystemVulnerabilitiesByID(rr, tt.r)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantStatus, rr.Code, "Expected http response code %d, got %d", tt.wantStatus, rr.Code)
+		})
+	}
+}
+
+func TestScanHandlers_GetScanServicesVulnerabilitiesByServiceID(t *testing.T) {
+	scanID := uuid.New()
+	vulnID := uuid.New()
+	serviceID := 42
+
+	tests := []struct {
+		name                string
+		scanService         interfaces.IScanService
+		vulnService         interfaces.IVulnerabilityService
+		scanScheduleService interfaces.IScanScheduleService
+		hostService         interfaces.IHostService
+		emailService        interfaces.IEmailService
+		eventBus            events.EventBus
+		r                   *http.Request
+		wantStatus          int
+		wantBodyContains    []string
+	}{
+		{
+			name:                "Bad ScanID → 400",
+			scanService:         &mock_services.MockScanService{},
+			vulnService:         &mock_services.MockVulnerabilityService{},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/invalid/services/42/vulnerabilities", nil)
+				r.SetPathValue("id", "invalid")
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Scan Not Found → 404",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return nil, customerrors.ErrScanNotFound
+				},
+			},
+			vulnService:         &mock_services.MockVulnerabilityService{},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusNotFound,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Scan Not Completed → 409",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "InProgress"}, nil
+				},
+			},
+			vulnService:         &mock_services.MockVulnerabilityService{},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusConflict,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Bad ServiceID → 400",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService:         &mock_services.MockVulnerabilityService{},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/invalid/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", "invalid")
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Error in Get Not Web Vulnerabilities → 500",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return nil, errors.New("error getting vuln for service")
+				},
+
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/invalid/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusInternalServerError,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Error in Get Web Vulnerabilities → 500",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return nil, errors.New("error getting web vuln for service")
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusInternalServerError,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Empty for No Web and web Vulnerabilities → 200",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusOK,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Empty for No Web Vulnerabilities but not empty for web→ 200",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{
+						{
+							VulnerabilityID: vulnID,
+						},
+					}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusOK,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Error in serviceID detail→ 500",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{
+						{
+							ID: vulnID,
+						},
+					}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{
+						{
+							VulnerabilityID: vulnID,
+						},
+					}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return nil, errors.New("error in fetch service")
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusInternalServerError,
+			wantBodyContains: []string{},
+		},
+
+		{
+			name: "Error in SeverityCounts → 500",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+				MockGetSeverityServiceCountsByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
+					return tools.SeverityCounts{}, errors.New("error in severityCounts")
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{
+						{
+							ID: vulnID,
+						},
+					}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{
+						{
+							VulnerabilityID: vulnID,
+						},
+					}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/"+strconv.Itoa(serviceID)+"/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", strconv.Itoa(serviceID))
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusInternalServerError,
+			wantBodyContains: []string{},
+		},
+		{
+			name: "Status OK → 200",
+			scanService: &mock_services.MockScanService{
+				MockGetScanByID: func(ctx context.Context, id uuid.UUID) (*domain.Scan, error) {
+					return &domain.Scan{Status: "Completed"}, nil
+				},
+				MockGetSeverityServiceCountsByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
+					return tools.SeverityCounts{
+						Critical: 1,
+						High:     2,
+						Medium:   3,
+						Low:      4,
+					}, nil
+				},
+			},
+			vulnService: &mock_services.MockVulnerabilityService{
+				MockGetServiceVulnerabilityDetailByScanAndServiceID: func(ctx context.Context, scanID uuid.UUID, serviceID int32) ([]domain.ScanVulnerabilityDetail, error) {
+					return []domain.ScanVulnerabilityDetail{
+						{
+							ID: vulnID,
+						},
+					}, nil
+				},
+				MockGetWebVulnerabilitiesForService: func(ctx context.Context, serviceID int32) ([]domain.WebVulnerability, error) {
+					return []domain.WebVulnerability{
+						{
+							VulnerabilityID: vulnID,
+						},
+					}, nil
+				},
+				MockGetServiceByID: func(ctx context.Context, serviceID int32) (*domain.Service, error) {
+					return &domain.Service{
+						SvName: "http",
+					}, nil
+				},
+			},
+			scanScheduleService: &mock_services.MockScanScheduleService{},
+			hostService:         &mock_services.MockHostService{},
+			emailService:        &mock_services.MockEmailService{},
+			eventBus:            &events.NatsEventBus{},
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/scans/"+scanID.String()+"/services/42/vulnerabilities", nil)
+				r.SetPathValue("id", scanID.String())
+				r.SetPathValue("service_id", "42")
+				r = r.WithContext(context.WithValue(r.Context(), middleware.ContextRoles, []domain.Role{domain.RoleAdmin}))
+				return r
+			}(),
+			wantStatus:       http.StatusOK,
+			wantBodyContains: []string{"http"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h := hh.NewScanHandlers(
+				tt.scanService,
+				tt.vulnService,
+				tt.scanScheduleService,
+				tt.hostService,
+				tt.emailService,
+				tt.eventBus,
+			)
+			err := h.GetScanServicesVulnerabilitiesByServiceID(rr, tt.r)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, rr.Code, "Expected http response code %d, got %d", tt.wantStatus, rr.Code)
+			body := rr.Body.String()
+			for _, substr := range tt.wantBodyContains {
+				assert.Contains(t, body, substr, "Response body should contain %q", substr)
+			}
+			// Additional validation for "Status OK → 200"
+			if tt.name == "Status OK → 200" && rr.Code == http.StatusOK {
+				var resp dto.ScanVulnerabilityDetectedServiceResponse
+				err := json.Unmarshal(rr.Body.Bytes(), &resp)
+				assert.NoError(t, err)
+				assert.Equal(t, "http", resp.ServiceName)
+				assert.Equal(t, 1, resp.SeverityCounts.Critical)
+				assert.Equal(t, 2, resp.SeverityCounts.High)
+				assert.Equal(t, 3, resp.SeverityCounts.Medium)
+				assert.Equal(t, 4, resp.SeverityCounts.Low)
+				//assert.Equal(t, "CVE-2024-0001", resp.Vulnerabilities[0].Name)
+				//assert.Equal(t, "Remediation description", resp.CWERemediations[0].Description)
+				//assert.Equal(t, "WebVuln", resp.WebVulnerabilities[0].Name)
+			}
 		})
 	}
 }

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -476,12 +476,12 @@ func (r *VulnerRepo) GetSeverityServiceCountsByScanID(ctx context.Context, scanI
 func (r *VulnerRepo) GetSeverityServiceCountsByScanAndServiceID(ctx context.Context, scanID uuid.UUID, serviceID int32) (tools.SeverityCounts, error) {
 	queries := r.getQueries(ctx)
 
-	args := repository.GetNetworkOSServicesVulnerabilityCountsByScanAndServiceIDParams{
+	args := repository.GetVulnerabilitySeverityCountsByScanAndServiceIDParams{
 		ScanID:    scanID,
 		ServiceID: sql.NullInt32{Int32: serviceID, Valid: true},
 	}
 
-	dbCounts, err := queries.GetNetworkOSServicesVulnerabilityCountsByScanAndServiceID(ctx, args)
+	dbCounts, err := queries.GetVulnerabilitySeverityCountsByScanAndServiceID(ctx, args)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return tools.SeverityCounts{}, customerrors.ErrScanNotFound
@@ -490,12 +490,12 @@ func (r *VulnerRepo) GetSeverityServiceCountsByScanAndServiceID(ctx context.Cont
 	}
 
 	counts := tools.SeverityCounts{
-		Unknown:  int(dbCounts.UnknownVulnerabilities),
-		None:     int(dbCounts.NoneVulnerabilities),
-		Low:      int(dbCounts.LowVulnerabilities),
-		Medium:   int(dbCounts.MediumVulnerabilities),
-		High:     int(dbCounts.HighVulnerabilities),
-		Critical: int(dbCounts.CriticalVulnerabilities),
+		Unknown:  int(dbCounts.UnknownCount),
+		None:     int(dbCounts.NoneCount),
+		Low:      int(dbCounts.LowCount),
+		Medium:   int(dbCounts.MediumCount),
+		High:     int(dbCounts.HighCount),
+		Critical: int(dbCounts.CriticalCount),
 	}
 	return counts, nil
 }
@@ -1264,7 +1264,8 @@ func (r *VulnerRepo) ListWebVulnerabilitiesByServiceID(ctx context.Context, serv
 				Reference:       dbVuln.Reference.String,
 				CreatedAt:       &dbVuln.CreatedAt.Time,
 				UpdatedAt:       &dbVuln.UpdatedAt.Time,
-				Instances:       []domain.WebVulnerabilityInstance{},
+				Title:           dbVuln.Title,
+				Severity:        dbVuln.Severity,
 			}
 			vulnMap[dbVuln.VulnerabilityID] = webVuln
 		}

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -1267,6 +1267,7 @@ func (r *VulnerRepo) ListWebVulnerabilitiesByServiceID(ctx context.Context, serv
 				UpdatedAt:       &dbVuln.UpdatedAt.Time,
 				Title:           dbVuln.Title,
 				Severity:        dbVuln.Severity,
+				Instances:       nil,
 			}
 			vulnMap[dbVuln.VulnerabilityID] = webVuln
 		}

--- a/pkg/storage/vulnerability.go
+++ b/pkg/storage/vulnerability.go
@@ -1091,6 +1091,7 @@ func populateVulnerabilityFromIntermediateDetails(domVuln *tools.Vulnerability, 
 		if domVuln.CveID != "" { // Only log if it's a known CVE that surprisingly has no metrics
 			slog.Info("No CVSS metrics found to populate top-level fields", "cve_id", domVuln.CveID)
 		}
+		domVuln.BaseSeverity = enums.SeverityTypeUnknown
 	}
 
 	// Map other direct fields


### PR DESCRIPTION
## Description 📖
This PR enhances the existing API endpoint `GET /api/scans/{scan_id}/services/{service_id}/vulnerabilities` by introducing a new field in the response DTO to include web vulnerability summaries. The changes ensure that both network and web vulnerabilities are returned efficiently without breaking existing functionality.

---

## Changes Implemented 🛠️

### 1. API Endpoint
- **Modified Endpoint**: `GET /api/scans/{scan_id}/services/{service_id}/vulnerabilities`
- **Response Update**: 
  - Added a new field `web_vulnerabilities` to the top-level response DTO.
  - `web_vulnerabilities` contains an array of `WebVulnerabilitySummary` objects.

### 2. DTO Implementation
- **New Field**: `web_vulnerabilities` added to the response DTO.
- **Conformance**: The `WebVulnerabilitySummary` structure adheres to the definitions in the DTO Definition Document.

### 3. Handler & Repository Layer
- **Handler Update**: 
  - The `VulnerabilityHandler` for obtaining vulnerabilities by serviceID method was updated to have the filling for web_vulnerabilities.
- **Repository Update**:
  - Update sql for severity count service using logic done for assets.
  - Update sql for service, returning title and severity.

### 4. Documentation & Testing
- **Swaggo Documentation**:
  - Updated the handler's Swaggo annotations to reflect the new `web_vulnerabilities` field in the response DTO.
- **Unit Tests**:
  - Added tests for the HTTP handler using the `httptest` package.
  - Verified correct response structure and status codes for both success and error cases.

---

Screenshots 📸

<img width="943" height="462" alt="Screenshot 2025-08-05 at 5 22 34 AM" src="https://github.com/user-attachments/assets/3bc3cccb-6065-486e-9fc9-ca8ba3d4a34e" />

---

## Checklist 📝
- [x] Updated response DTO with `web_vulnerabilities`.
- [x] Implemented `WebVulnerabilitySummary` structure.
- [x] Updated service and repository layers.
- [x] Added Swaggo documentation for the updated endpoint.
- [x] Wrote unit tests for the HTTP handler.
- [x] Verified existing functionality remains


---
### 4. Minor Fix: Missing Severity in Vulnerabilities
- **Affected Endpoint**: `GET /api/scans/{scan_id}/operating-system/vulnerabilities`
- **Issue 1**: A vulnerability with an empty severity was encountered when the CVSS metric had no information.
- **Issue 2**: The total vulnerability was affected by the first issue, and not unknown  was count 
- **Fix 1**: 
  - Updated the logic to set the severity to `unknown` when no CVSS metrics are available.
    ```go
    if primaryMetric != nil {
        // ...existing code...
    } else {
        domVuln.BaseSeverity = "unknown" // Default severity when no metrics are available
        if domVuln.CveID != "" {
            slog.Info("No CVSS metrics found to populate top-level fields", "cve_id", domVuln.CveID)
        }
    }
    ```
- **Fix 2**:
    -  Include in the summation the counts for none and unknown 
```go
		TotalVulnerabilities: severityCounts.Critical + severityCounts.High + severityCounts.Medium + severityCounts.Low + severityCounts.None + severityCounts.Unknown,
```