### PR TITLE
Task/kt 542 add owasp category to CWE database layer

### DIFF
--- a/db/cwe_detail.sql.go
+++ b/db/cwe_detail.sql.go
@@ -16,21 +16,24 @@ INSERT INTO cwe_details (
     cwe_id,
     title,
     description,
-    last_updated
+    last_updated,
+    owasp_top10_category
 ) VALUES (
-  $1, $2, $3, $4
+  $1, $2, $3, $4, $5
 ) ON CONFLICT (cwe_id) DO UPDATE SET
   title = EXCLUDED.title,
   description = EXCLUDED.description,
-  last_updated = EXCLUDED.last_updated
-RETURNING cwe_id, title, description, last_updated, created_at
+  last_updated = EXCLUDED.last_updated,
+  owasp_top10_category = EXCLUDED.owasp_top10_category
+RETURNING cwe_id, title, description, last_updated, created_at, owasp_top10_category
 `
 
 type CreateOrUpdateCWEDetailParams struct {
-	CweID       string    `json:"cwe_id"`
-	Title       string    `json:"title"`
-	Description string    `json:"description"`
-	LastUpdated time.Time `json:"last_updated"`
+	CweID              string         `json:"cwe_id"`
+	Title              string         `json:"title"`
+	Description        string         `json:"description"`
+	LastUpdated        time.Time      `json:"last_updated"`
+	OwaspTop10Category sql.NullString `json:"owasp_top10_category"`
 }
 
 func (q *Queries) CreateOrUpdateCWEDetail(ctx context.Context, arg CreateOrUpdateCWEDetailParams) (CweDetail, error) {
@@ -39,6 +42,7 @@ func (q *Queries) CreateOrUpdateCWEDetail(ctx context.Context, arg CreateOrUpdat
 		arg.Title,
 		arg.Description,
 		arg.LastUpdated,
+		arg.OwaspTop10Category,
 	)
 	var i CweDetail
 	err := row.Scan(
@@ -47,12 +51,13 @@ func (q *Queries) CreateOrUpdateCWEDetail(ctx context.Context, arg CreateOrUpdat
 		&i.Description,
 		&i.LastUpdated,
 		&i.CreatedAt,
+		&i.OwaspTop10Category,
 	)
 	return i, err
 }
 
 const getCWEDetailByCWEID = `-- name: GetCWEDetailByCWEID :one
-SELECT cwe_id, title, description, last_updated, created_at
+SELECT cwe_id, title, description, last_updated, created_at, owasp_top10_category
 FROM cwe_details
 WHERE cwe_id = $1
 `
@@ -66,6 +71,7 @@ func (q *Queries) GetCWEDetailByCWEID(ctx context.Context, cweID string) (CweDet
 		&i.Description,
 		&i.LastUpdated,
 		&i.CreatedAt,
+		&i.OwaspTop10Category,
 	)
 	return i, err
 }
@@ -75,6 +81,7 @@ SELECT
   cd.cwe_id,
   cd.title,
   cd.description,
+  cd.owasp_top10_category,
   cm.mitigation_id,
   cm.phase,
   cm.description AS mitigation_description,
@@ -90,6 +97,7 @@ type GetCWEDetailWithMitigationsByIDRow struct {
 	CweID                 string         `json:"cwe_id"`
 	Title                 string         `json:"title"`
 	Description           string         `json:"description"`
+	OwaspTop10Category    sql.NullString `json:"owasp_top10_category"`
 	MitigationID          sql.NullString `json:"mitigation_id"`
 	Phase                 sql.NullString `json:"phase"`
 	MitigationDescription sql.NullString `json:"mitigation_description"`
@@ -111,6 +119,7 @@ func (q *Queries) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID str
 			&i.CweID,
 			&i.Title,
 			&i.Description,
+			&i.OwaspTop10Category,
 			&i.MitigationID,
 			&i.Phase,
 			&i.MitigationDescription,

--- a/db/db_tool/main.go
+++ b/db/db_tool/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kptm-tools/common/common/pkg/enums"
 	repository "github.com/kptm-tools/core-service/db"
 	migrations "github.com/kptm-tools/core-service/db/sql"
 	"github.com/kptm-tools/core-service/pkg/config"
@@ -269,13 +270,13 @@ func populateCWE() {
 			ID:                 "CWE-Other",
 			Name:               "Other or Uncategorized Weakness",
 			Description:        "This vulnerability falls into a category that is not otherwise classified. Further manual analysis is recommended.",
-			OwaspTop10Category: "Other",
+			OwaspTop10Category: enums.OwaspCategoryOther.String(),
 		},
 		{
 			ID:                 "CWE-noinfo",
 			Name:               "No Information Available",
 			Description:        "The scanning tool did not provide a specific weakness classification for this finding.",
-			OwaspTop10Category: "No Info",
+			OwaspTop10Category: enums.OwaspCategoryNoInfo.String(),
 		},
 	}
 

--- a/db/db_tool/main.go
+++ b/db/db_tool/main.go
@@ -260,28 +260,32 @@ func populateCWE() {
 	logger.Info("Inserting special CWE records for edge cases...")
 
 	specialCWEs := []struct {
-		ID          string
-		Name        string
-		Description string
+		ID                 string
+		Name               string
+		Description        string
+		OwaspTop10Category string
 	}{
 		{
-			ID:          "CWE-Other",
-			Name:        "Other or Uncategorized Weakness",
-			Description: "This vulnerability falls into a category that is not otherwise classified. Further manual analysis is recommended.",
+			ID:                 "CWE-Other",
+			Name:               "Other or Uncategorized Weakness",
+			Description:        "This vulnerability falls into a category that is not otherwise classified. Further manual analysis is recommended.",
+			OwaspTop10Category: "Other",
 		},
 		{
-			ID:          "CWE-noinfo",
-			Name:        "No Information Available",
-			Description: "The scanning tool did not provide a specific weakness classification for this finding.",
+			ID:                 "CWE-noinfo",
+			Name:               "No Information Available",
+			Description:        "The scanning tool did not provide a specific weakness classification for this finding.",
+			OwaspTop10Category: "No Info",
 		},
 	}
 
 	for _, special := range specialCWEs {
 		_, err := queries.CreateOrUpdateCWEDetail(ctx, repository.CreateOrUpdateCWEDetailParams{
-			CweID:       special.ID,
-			Title:       special.Name,
-			Description: special.Description,
-			LastUpdated: time.Now().UTC(),
+			CweID:              special.ID,
+			Title:              special.Name,
+			Description:        special.Description,
+			LastUpdated:        time.Now().UTC(),
+			OwaspTop10Category: sql.NullString{String: special.OwaspTop10Category, Valid: true},
 		})
 		if err != nil {
 			logger.Error("Failed to insert special CWE record",
@@ -298,10 +302,11 @@ func populateCWE() {
 	for cweID, weakness := range cweData {
 		// Insert/update the main CWE detail
 		_, err := queries.CreateOrUpdateCWEDetail(ctx, repository.CreateOrUpdateCWEDetailParams{
-			CweID:       cweID,
-			Title:       weakness.Name,
-			Description: weakness.Description,
-			LastUpdated: weakness.LastUpdated,
+			CweID:              cweID,
+			Title:              weakness.Name,
+			Description:        weakness.Description,
+			LastUpdated:        weakness.LastUpdated,
+			OwaspTop10Category: sql.NullString{String: weakness.OwaspTop10Category, Valid: weakness.OwaspTop10Category != ""},
 		})
 		if err != nil {
 			logger.Error("Failed to insert/update CWE detail",

--- a/db/models.go
+++ b/db/models.go
@@ -298,11 +298,12 @@ type CveDetail struct {
 }
 
 type CweDetail struct {
-	CweID       string       `json:"cwe_id"`
-	Title       string       `json:"title"`
-	Description string       `json:"description"`
-	LastUpdated time.Time    `json:"last_updated"`
-	CreatedAt   sql.NullTime `json:"created_at"`
+	CweID              string         `json:"cwe_id"`
+	Title              string         `json:"title"`
+	Description        string         `json:"description"`
+	LastUpdated        time.Time      `json:"last_updated"`
+	CreatedAt          sql.NullTime   `json:"created_at"`
+	OwaspTop10Category sql.NullString `json:"owasp_top10_category"`
 }
 
 type CweMitigation struct {

--- a/db/sql/migrations/000030_add_owasp_top10_category_to_cwe_details.down.sql
+++ b/db/sql/migrations/000030_add_owasp_top10_category_to_cwe_details.down.sql
@@ -1,0 +1,3 @@
+-- Remove owasp_top10_category column from cwe_details table
+ALTER TABLE cwe_details
+DROP COLUMN owasp_top10_category;

--- a/db/sql/migrations/000030_add_owasp_top10_category_to_cwe_details.up.sql
+++ b/db/sql/migrations/000030_add_owasp_top10_category_to_cwe_details.up.sql
@@ -1,0 +1,3 @@
+-- Add owasp_top10_category column to cwe_details table
+ALTER TABLE cwe_details
+ADD COLUMN owasp_top10_category VARCHAR(255);

--- a/db/sql/queries/cwe_detail.sql
+++ b/db/sql/queries/cwe_detail.sql
@@ -3,17 +3,19 @@ INSERT INTO cwe_details (
     cwe_id,
     title,
     description,
-    last_updated
+    last_updated,
+    owasp_top10_category
 ) VALUES (
-  $1, $2, $3, $4
+  $1, $2, $3, $4, $5
 ) ON CONFLICT (cwe_id) DO UPDATE SET
   title = EXCLUDED.title,
   description = EXCLUDED.description,
-  last_updated = EXCLUDED.last_updated
+  last_updated = EXCLUDED.last_updated,
+  owasp_top10_category = EXCLUDED.owasp_top10_category
 RETURNING *;
 
 -- name: GetCWEDetailByCWEID :one
-SELECT cwe_id, title, description, last_updated, created_at
+SELECT cwe_id, title, description, last_updated, created_at, owasp_top10_category
 FROM cwe_details
 WHERE cwe_id = $1;
 
@@ -22,6 +24,7 @@ SELECT
   cd.cwe_id,
   cd.title,
   cd.description,
+  cd.owasp_top10_category,
   cm.mitigation_id,
   cm.phase,
   cm.description AS mitigation_description,

--- a/db/vulnerability.sql.go
+++ b/db/vulnerability.sql.go
@@ -311,7 +311,7 @@ const getVulnerabilitiesWithDetailsByScanID = `-- name: GetVulnerabilitiesWithDe
 SELECT 
   v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id,
   cve.id, cve.cve_id, cve.published_date, cve.last_modified_date, cve.cvss_v2_vector, cve.cvss_v2_base_score, cve.cvss_v2_base_severity, cve.cvss_v2_exploitability_score, cve.cvss_v2_impact_score, cve.cvss_v2_access_vector, cve.cvss_v2_access_complexity, cve.cvss_v2_authentication, cve.cvss_v2_confidentiality_impact, cve.cvss_v2_integrity_impact, cve.cvss_v2_availability_impact, cve.cvss_v30_vector, cve.cvss_v30_base_score, cve.cvss_v30_base_severity, cve.cvss_v30_exploitability_score, cve.cvss_v30_impact_score, cve.cvss_v30_attack_vector, cve.cvss_v30_attack_complexity, cve.cvss_v30_privileges_required, cve.cvss_v30_user_interaction, cve.cvss_v30_scope, cve.cvss_v30_confidentiality_impact, cve.cvss_v30_integrity_impact, cve.cvss_v30_availability_impact, cve.cvss_v31_vector, cve.cvss_v31_base_score, cve.cvss_v31_base_severity, cve.cvss_v31_exploitability_score, cve.cvss_v31_exploit_code_maturity, cve.cvss_v31_impact_score, cve.cvss_v31_attack_vector, cve.cvss_v31_attack_complexity, cve.cvss_v31_privileges_required, cve.cvss_v31_user_interaction, cve.cvss_v31_scope, cve.cvss_v31_confidentiality_impact, cve.cvss_v31_integrity_impact, cve.cvss_v31_availability_impact, cve.epss_score, cve.epss_percentile, cve.risk_score, cve.likelihood, cve.nvd_description, cve.nvd_references, cve.vendor_comments, cve.created_at, cve.updated_at,
-  cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at
+  cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at, cwe.owasp_top10_category
 FROM
   vulnerabilities AS v
 LEFT JOIN
@@ -394,6 +394,7 @@ type GetVulnerabilitiesWithDetailsByScanIDRow struct {
 	Description_2                sql.NullString        `json:"description_2"`
 	LastUpdated                  sql.NullTime          `json:"last_updated"`
 	CreatedAt_3                  sql.NullTime          `json:"created_at_3"`
+	OwaspTop10Category           sql.NullString        `json:"owasp_top10_category"`
 }
 
 func (q *Queries) GetVulnerabilitiesWithDetailsByScanID(ctx context.Context, scanID uuid.UUID) ([]GetVulnerabilitiesWithDetailsByScanIDRow, error) {
@@ -475,6 +476,7 @@ func (q *Queries) GetVulnerabilitiesWithDetailsByScanID(ctx context.Context, sca
 			&i.Description_2,
 			&i.LastUpdated,
 			&i.CreatedAt_3,
+			&i.OwaspTop10Category,
 		); err != nil {
 			return nil, err
 		}
@@ -732,7 +734,7 @@ const getVulnerabilityWithDetailsByID = `-- name: GetVulnerabilityWithDetailsByI
 SELECT 
   v.id, v.host_id, v.scan_id, v.cve_id, v.title, v.description, v.severity, v.vuln_source, v.vuln_type, v.analyst_comment, v.created_at, v.updated_at, v.cwe_id,
   cve.id, cve.cve_id, cve.published_date, cve.last_modified_date, cve.cvss_v2_vector, cve.cvss_v2_base_score, cve.cvss_v2_base_severity, cve.cvss_v2_exploitability_score, cve.cvss_v2_impact_score, cve.cvss_v2_access_vector, cve.cvss_v2_access_complexity, cve.cvss_v2_authentication, cve.cvss_v2_confidentiality_impact, cve.cvss_v2_integrity_impact, cve.cvss_v2_availability_impact, cve.cvss_v30_vector, cve.cvss_v30_base_score, cve.cvss_v30_base_severity, cve.cvss_v30_exploitability_score, cve.cvss_v30_impact_score, cve.cvss_v30_attack_vector, cve.cvss_v30_attack_complexity, cve.cvss_v30_privileges_required, cve.cvss_v30_user_interaction, cve.cvss_v30_scope, cve.cvss_v30_confidentiality_impact, cve.cvss_v30_integrity_impact, cve.cvss_v30_availability_impact, cve.cvss_v31_vector, cve.cvss_v31_base_score, cve.cvss_v31_base_severity, cve.cvss_v31_exploitability_score, cve.cvss_v31_exploit_code_maturity, cve.cvss_v31_impact_score, cve.cvss_v31_attack_vector, cve.cvss_v31_attack_complexity, cve.cvss_v31_privileges_required, cve.cvss_v31_user_interaction, cve.cvss_v31_scope, cve.cvss_v31_confidentiality_impact, cve.cvss_v31_integrity_impact, cve.cvss_v31_availability_impact, cve.epss_score, cve.epss_percentile, cve.risk_score, cve.likelihood, cve.nvd_description, cve.nvd_references, cve.vendor_comments, cve.created_at, cve.updated_at,
-  cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at
+  cwe.cwe_id, cwe.title, cwe.description, cwe.last_updated, cwe.created_at, cwe.owasp_top10_category
 FROM
   vulnerabilities AS v
 LEFT JOIN
@@ -813,6 +815,7 @@ type GetVulnerabilityWithDetailsByIDRow struct {
 	Description_2                sql.NullString        `json:"description_2"`
 	LastUpdated                  sql.NullTime          `json:"last_updated"`
 	CreatedAt_3                  sql.NullTime          `json:"created_at_3"`
+	OwaspTop10Category           sql.NullString        `json:"owasp_top10_category"`
 }
 
 func (q *Queries) GetVulnerabilityWithDetailsByID(ctx context.Context, id uuid.UUID) (GetVulnerabilityWithDetailsByIDRow, error) {
@@ -888,6 +891,7 @@ func (q *Queries) GetVulnerabilityWithDetailsByID(ctx context.Context, id uuid.U
 		&i.Description_2,
 		&i.LastUpdated,
 		&i.CreatedAt_3,
+		&i.OwaspTop10Category,
 	)
 	return i, err
 }

--- a/docs/adr/ADR-005.md
+++ b/docs/adr/ADR-005.md
@@ -1,0 +1,40 @@
+# ADR-005: Persist OWASP Category as a Static Attribute of CWEs
+
+**Status:** Accepted
+**Date:** 2025-08-02
+
+## 💭 Context
+
+Our system needs to display the 2021 OWASP Top 10 category for each vulnerability. This category is derived from the vulnerability's associated Common Weakness Enumeration (CWE) ID.
+
+The previous architecture performed this mapping at runtime. A Go function in the `enums` package contained a large map (`cweID -> OwaspCategory`) and was called every time a vulnerability's details were fetched. This approach had several drawbacks:
+
+* **Performance:** It added a small but repeated computational overhead to every request that needed this data.
+* **Data Silo:** The mapping logic was hidden within the application code, making it impossible to query or aggregate by OWASP category directly in the database.
+* **Code Complexity:** It bloated the `enums` package with a large, static data map that is only tangentially related to the core purpose of enums.
+
+## 💪 Decision
+
+We will refactor the system to treat the OWASP Top 10 category as a **static, persisted attribute** of a CWE.
+
+1. **Schema Change:** The `cwe_details` table will be modified to include a new nullable column: `owasp_top10_category VARCHAR(255)`.
+2. **Data Population:** The database pre-population script (e.g., `cmd/db-tool`) will be the single source of truth for this mapping. When seeding the `cwe_details` table from the `cwe.json` file, it will:
+    * First, attempt to find the category directly within the JSON data.
+    * If not found, it will use a fallback Go function to calculate it.
+    * The resulting category will be inserted into the new database column.
+3. **Code Simplification:** The runtime mapping logic (the large map and lookup function) will be completely removed from the Go application code. The `domain.CWEDetail` struct will be updated to include the `OwaspTop10Category` field, which will be populated directly from the database.
+
+## ➡️ Consequences
+
+### ✅ Positive
+
+* **Improved Performance:** The expensive mapping logic is executed only once during data seeding, not on every API request. Data retrieval is a simple and fast `SELECT`.
+* **Enhanced Querying Capabilities:** We can now run powerful analytical queries directly against the database (e.g., `GROUP BY owasp_top10_category`), which is essential for dashboards and reporting.
+* **Single Source of Truth:** The database becomes the canonical source for all CWE-related data, including its OWASP category.
+* **Cleaner Codebase:** The Go application code is simplified by removing the large, static mapping logic from the `enums` package.
+
+### ❌ Negative
+
+* **New Operational Step:** Setting up a new development environment or updating the CWE data now requires an explicit, manual step: running the pre-population script. This needs to be clearly documented.
+* **Potential for Stale Data:** If the OWASP Top 10 list is updated, the pre-population script must be re-run to update the database. There is a potential for the data in the database to be slightly out of sync with the absolute latest external standard until the script is run.
+* **Stub Records:** The database may contain incomplete "stub" records for new or unknown CWEs, which will require a separate process to monitor and enrich over time.

--- a/pkg/domain/cwe.go
+++ b/pkg/domain/cwe.go
@@ -7,10 +7,11 @@ import "time"
 // It assumes CWE data is pre-populated in the database and should not be created on-the-fly.
 type CWEDetailWithMitigations struct {
 	// CWE Detail fields (from cwe_details table)
-	CweID       string    `json:"cwe_id"`
-	Title       string    `json:"title"`
-	Description string    `json:"description"`
-	LastUpdated time.Time `json:"last_updated"`
+	CweID              string    `json:"cwe_id"`
+	Title              string    `json:"title"`
+	Description        string    `json:"description"`
+	LastUpdated        time.Time `json:"last_updated"`
+	OwaspTop10Category string    `json:"owasp_top10_category,omitempty"`
 
 	// Mitigation fields (from cwe_mitigations table)
 	MitigationID          string    `json:"mitigation_id,omitempty"`
@@ -25,11 +26,12 @@ type CWEDetailWithMitigations struct {
 // This is used when only the basic CWE information is needed.
 // Maintains backward compatibility with existing code.
 type CWEDetail struct {
-	ID          string     `json:"cwe_id"` // Renamed from CweID for backward compatibility
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	CreatedAt   *time.Time `json:"created_at"`   // Maintained for backward compatibility
-	LastUpdated *time.Time `json:"last_updated"` // Maintained for backward compatibility
+	ID                 string     `json:"cwe_id"` // Renamed from CweID for backward compatibility
+	Title              string     `json:"title"`
+	Description        string     `json:"description"`
+	CreatedAt          *time.Time `json:"created_at"`   // Maintained for backward compatibility
+	LastUpdated        *time.Time `json:"last_updated"` // Maintained for backward compatibility
+	OwaspTop10Category string     `json:"owasp_top10_category,omitempty"`
 }
 
 // CWEMitigation represents a single mitigation strategy for a CWE.

--- a/pkg/services/cwe.go
+++ b/pkg/services/cwe.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/core-service/pkg/dto"
 )
 
@@ -20,11 +21,12 @@ func NewCWEParser() *CWEParser {
 
 // ParsedCWE represents a parsed CWE weakness with calculated fields
 type ParsedCWE struct {
-	ID          string
-	Name        string
-	Description string
-	LastUpdated time.Time
-	Mitigations []ParsedMitigation
+	ID                 string
+	Name               string
+	Description        string
+	LastUpdated        time.Time
+	Mitigations        []ParsedMitigation
+	OwaspTop10Category string
 }
 
 // ParsedMitigation represents a parsed mitigation strategy
@@ -62,12 +64,16 @@ func (p *CWEParser) LoadCWE(filePath string) (map[string]ParsedCWE, error) {
 		// Parse mitigations
 		mitigations := p.parseMitigations(w.PotentialMitigations)
 
+		// Get OWASP Top 10 category
+		owaspCategory := enums.GetOwaspCategoryForCWE(cweID).String()
+
 		parsed := ParsedCWE{
-			ID:          cweID,
-			Name:        w.Name,
-			Description: w.Description,
-			LastUpdated: lastUpdated,
-			Mitigations: mitigations,
+			ID:                 cweID,
+			Name:               w.Name,
+			Description:        w.Description,
+			LastUpdated:        lastUpdated,
+			Mitigations:        mitigations,
+			OwaspTop10Category: owaspCategory,
 		}
 
 		result[cweID] = parsed

--- a/pkg/storage/cwe.go
+++ b/pkg/storage/cwe.go
@@ -145,6 +145,7 @@ func (r *CWERepo) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID str
 			CweID:                 dbCWE.CweID,
 			Title:                 dbCWE.Title,
 			Description:           dbCWE.Description,
+			OwaspTop10Category:    dbCWE.OwaspTop10Category.String,
 			MitigationID:          dbCWE.MitigationID.String,
 			Phase:                 dbCWE.Phase.String,
 			MitigationDescription: dbCWE.MitigationDescription.String,
@@ -173,10 +174,11 @@ func (r *CWERepo) GetCWEByID(ctx context.Context, cweID string) (*domain.CWEDeta
 	}
 
 	return &domain.CWEDetail{
-		ID:          dbCWE.CweID,
-		Title:       dbCWE.Title,
-		Description: dbCWE.Description,
-		LastUpdated: &dbCWE.LastUpdated,
+		ID:                 dbCWE.CweID,
+		Title:              dbCWE.Title,
+		Description:        dbCWE.Description,
+		LastUpdated:        &dbCWE.LastUpdated,
+		OwaspTop10Category: dbCWE.OwaspTop10Category.String,
 	}, nil
 }
 
@@ -195,10 +197,11 @@ func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWED
 
 	// Create a stub record with minimal information
 	params := repository.CreateOrUpdateCWEDetailParams{
-		CweID:       cweID,
-		Title:       "Unknown Weakness",
-		Description: "This CWE ID was not found in the pre-populated knowledge base. Manual review recommended.",
-		LastUpdated: time.Now().UTC(),
+		CweID:              cweID,
+		Title:              "Unknown Weakness",
+		Description:        "This CWE ID was not found in the pre-populated knowledge base. Manual review recommended.",
+		LastUpdated:        time.Now().UTC(),
+		OwaspTop10Category: sql.NullString{String: "No Info", Valid: true},
 	}
 
 	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)
@@ -207,9 +210,10 @@ func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWED
 	}
 
 	return &domain.CWEDetail{
-		ID:          dbCWE.CweID,
-		Title:       dbCWE.Title,
-		Description: dbCWE.Description,
-		LastUpdated: &dbCWE.LastUpdated,
+		ID:                 dbCWE.CweID,
+		Title:              dbCWE.Title,
+		Description:        dbCWE.Description,
+		LastUpdated:        &dbCWE.LastUpdated,
+		OwaspTop10Category: dbCWE.OwaspTop10Category.String,
 	}, nil
 }

--- a/pkg/storage/cwe.go
+++ b/pkg/storage/cwe.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"context"
 	"database/sql"
-	"github.com/kptm-tools/core-service/pkg/domain"
 	"strconv"
 	"time"
 
+	"github.com/kptm-tools/core-service/pkg/domain"
+
+	"github.com/kptm-tools/common/common/pkg/enums"
 	"github.com/kptm-tools/common/common/pkg/results/tools"
 	repository "github.com/kptm-tools/core-service/db"
 	"github.com/kptm-tools/core-service/pkg/interfaces"
@@ -140,7 +142,6 @@ func (r *CWERepo) GetCWEDetailWithMitigationsByID(ctx context.Context, cweID str
 
 	remediationDetails := make([]domain.CWEDetailWithMitigations, len(dbCWEs))
 	for i, dbCWE := range dbCWEs {
-
 		remediationDetails[i] = domain.CWEDetailWithMitigations{
 			CweID:                 dbCWE.CweID,
 			Title:                 dbCWE.Title,
@@ -201,7 +202,7 @@ func (r *CWERepo) CreateCWEStub(ctx context.Context, cweID string) (*domain.CWED
 		Title:              "Unknown Weakness",
 		Description:        "This CWE ID was not found in the pre-populated knowledge base. Manual review recommended.",
 		LastUpdated:        time.Now().UTC(),
-		OwaspTop10Category: sql.NullString{String: "No Info", Valid: true},
+		OwaspTop10Category: sql.NullString{String: enums.OwaspCategoryNoInfo.String(), Valid: true},
 	}
 
 	dbCWE, err := queries.CreateOrUpdateCWEDetail(ctx, params)


### PR DESCRIPTION
## Description 📖

  This feature adds OWASP Top 10 2021 category persistence for CWE (Common Weakness Enumeration) details,
  enabling the system to store and retrieve the OWASP category mapping for each CWE in the database.

---
## Acceptance Criteria ✅

### Database Schema

  - **New Column:** owasp_top10_category VARCHAR(255) added to the cwe_details table via a reversible migration.
  - **Migration Files:** Created 000030_add_owasp_top10_category_to_cwe_details.up.sql and corresponding down
  migration.

### Data Population

  - **CWE Parser:** Enhanced to determine OWASP category for each CWE using the GetOwaspCategoryForCWE function from
  the common package.
  - **Pre-population Script:** Updated cmd/db-tool to populate the new owasp_top10_category column for all CWE
  records.
  - **Special Cases:** Handles edge cases like "CWE-Other" and "CWE-noinfo" with appropriate OWASP categories.

### Data Access Layer

  - Domain Models: Updated CWEDetail and CWEDetailWithMitigations structs to include OwaspTop10Category field.
  - SQLC Queries: Modified all CWE-related queries (GetCWEDetailByCWEID, GetCWEDetailWithMitigationsByID,
  CreateOrUpdateCWEDetail) to include the new column.
  - Repository Mappers: Updated all mapper functions to correctly map the owasp_top10_category column between
  database and domain models.

  ---
## Changes Implemented 🛠️

  1. Database Migration: Added migration files to create the owasp_top10_category column in the cwe_details
  table.
  2. Domain Models: Added OwaspTop10Category field to both CWEDetail and CWEDetailWithMitigations structs.
  3. SQLC Updates:
    - Modified SQL queries to select and insert the new column
    - Regenerated SQLC code to include the field in generated models
  4. CWE Parser: Updated to populate OWASP category using the common package's mapping function.
  5. Data Population Script: Enhanced populate-cwe command to populate OWASP categories for all CWE records.
  6. Repository Layer: Updated all CWE repository mappers to handle the new field.

  ---
## Technical Details 🔧

  - OWASP Mapping: Leverages existing enums.GetOwaspCategoryForCWE() function from the common package
  - Category Values: Maps to OWASP Top 10 2021 categories (e.g., "Injection", "Broken Access Control", etc.)
  - Fallback Handling: Unknown CWEs map to "No Info", CWEs not in Top 10 map to "Other"
  - Null Handling: Uses sql.NullString for database operations to handle nullable column


