### PR TITLE
Bug/kt 552 add CWE json to core service dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.24.4
 WORKDIR /app
 
 COPY go.mod go.sum ./
+COPY Makefile ./
 
 RUN go mod download
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY db/ ./db
 
 COPY docs/ ./docs
 
+COPY data/ ./data
+
 RUN CGO_ENABLED=0 GOOS=linux go build -o ./bin/core-service ./cmd/main.go
 
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ clear: confirm
 
 ## audit: run quality control checks (static, vulnerabilities, etc)
 .PHONY: audit
-audit: test
+audit: test test/cwe
 	go mod tidy -diff
 	go mod verify
 	test -z "$(shell gofmt -l .)" 
@@ -137,6 +137,11 @@ audit: test
 .PHONY: test
 test:
 	go test -v -race -buildvcs ./...
+
+## test/cwe: validate CWE JSON parsing
+.PHONY: test/cwe
+test/cwe:
+	go run ./cmd/test-cwe/main.go
 
 ## test/cover: run all tests and display coverage
 .PHONY: test/cover


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [x] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR updated the `Dockerfile` for `core-service`, ensuring that copy commands are included for both our `Makefile` and `cwe.json` files. 

This will allow us to run `make` commands directly from the container 🚀 

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue [#KT-552](https://deltateam.atlassian.net/browse/KT-552?atlOrigin=eyJpIjoiMGJhYWExNTUyNTRkNDhmNGEyOWIzODBlZGM3ZmM3YjQiLCJwIjoiaiJ9)


## 🧪 QA Instructions, Screenshots, Recordings

<img width="1064" height="508" alt="image" src="https://github.com/user-attachments/assets/b140d1e0-b826-49a7-ae32-df0bc70dcc7c" />
