### PR TITLE
fix: Update ConvertScanOSandServicesResultToResponse index out of range

### DIFF
--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -703,8 +703,10 @@ func ConvertScanOSandServicesResultToResponse(results []domain.ScanOSandServices
 		switch r.AssetType {
 		case "os":
 			cpeSplit := strings.Split(r.Cpe, ":")
-			version := cpeSplit[len(cpeSplit)-1]
-			name := cpeSplit[len(cpeSplit)-2]
+			var version string
+			if len(cpeSplit) > 0 {
+				version = cpeSplit[len(cpeSplit)-1]
+			}
 
 			// Map OS
 			response.OperatingSystem = ScanAssetsOperatingSystem{
@@ -712,7 +714,7 @@ func ConvertScanOSandServicesResultToResponse(results []domain.ScanOSandServices
 				HostID:   r.HostID.String(),
 				ScanID:   r.ScanID.String(),
 				FullName: r.Name,
-				Name:     name,
+				Name:     r.Name,
 				Version:  version,
 				Family:   r.Family,
 				OSType:   r.OsType,

--- a/pkg/dto/response.go
+++ b/pkg/dto/response.go
@@ -703,10 +703,7 @@ func ConvertScanOSandServicesResultToResponse(results []domain.ScanOSandServices
 		switch r.AssetType {
 		case "os":
 			cpeSplit := strings.Split(r.Cpe, ":")
-			var version string
-			if len(cpeSplit) > 0 {
-				version = cpeSplit[len(cpeSplit)-1]
-			}
+			version := cpeSplit[len(cpeSplit)-1]
 
 			// Map OS
 			response.OperatingSystem = ScanAssetsOperatingSystem{


### PR DESCRIPTION
This pull request improves the robustness of the OS asset parsing logic in the `ConvertScanOSandServicesResultToResponse` function. The main change is to ensure that the code safely handles cases where the `cpeSplit` array may be empty, preventing potential panics, and to use the asset's actual name rather than extracting it from the CPE string.

Parsing and assignment improvements:

* Added a check to ensure `version` is only assigned if `cpeSplit` has elements, preventing index-out-of-range errors.
* Updated the assignment of the `Name` field in `ScanAssetsOperatingSystem` to use `r.Name` directly instead of extracting it from the CPE string.